### PR TITLE
Queue mixin for defining Queue classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,13 @@ Run a worker to handle jobs on the queue:
 $ qs start main
 ```
 
-Qs is a framework for running message queues.  There APIs for both submitting bg jobs and publishing and subscribing to event jobs.
+Qs is a framework for running message queues.  There are APIs for both submitting bg jobs and publishing and subscribing to event jobs.
+
+TODO: code snippets for both adding jobs and publishing events
+
+# Redis
+
+TODO: add a note about redis usage and connecting
 
 ## Installation
 

--- a/lib/qs.rb
+++ b/lib/qs.rb
@@ -1,7 +1,10 @@
+require 'set'
 require 'logger'
 require 'stringio'
 require 'ns-options'
 require 'qs/version'
+require 'qs/redis_connection'
+require 'qs/queue'
 
 module Qs
 
@@ -9,11 +12,39 @@ module Qs
   def self.configure(&block); Config.define(&block); end
 
   def self.init
-    # TODO: lib init code goes here...
+    self.after_fork
+  end
+
+  def self.after_fork
+    @redis = Qs::RedisConnection.new(Qs.config.redis)
+  end
+
+  # queues needs to be available lazyily -- queues may try to register
+  # themselves with Qs before it has run its `init`
+
+  def self.queues; @queues ||= QueueSet.new; end
+  def self.register(queue); self.queues.add(queue); end
+
+  def self.redis(&block)
+    raise ArgumentError, "requires a block" if !block
+    raise RuntimeError,  "no redis connection - call `Qs.init`" if @redis.nil?
+    @redis.with(&block)
   end
 
   class Config
     include NsOptions::Proxy
+
+    option :queue_key_prefix, String, :default => 'qs'
+    option :platform,         String, :default => 'ruby'
+    option :version,          String, :default => Qs::VERSION
+
+    namespace :redis do
+      option :url,      String, :default => 'redis://localhost:6379/0'
+      option :redis_ns, String, :default => 'qs'
+      option :size,     Fixnum, :default => 5
+      option :timeout,  Fixnum, :default => 1
+      option :driver,   String, :default => 'ruby'
+    end
 
     option :timeout, Fixnum, :default => proc { Qs::Config.default_timeout }
     option :logger,          :default => proc { Qs::Config.null_logger }
@@ -25,6 +56,53 @@ module Qs
     def self.null_logger
       @null_logger ||= Logger.new(StringIO.new)
     end
+
+  end
+
+  class QueueSet < ::Set
+
+    # manage subscriptions across all queues
+
+    def list_subscriptions(out)
+      self.each do |queue|
+        log_subscriptions(out, queue)
+      end
+    end
+
+    def sync_subscriptions(out)
+      log out, "Syncing subscriptions for all queues..."
+
+      self.each do |queue|
+        queue.sync_subscriptions
+        log_subscriptions(out, queue)
+      end
+    end
+
+    def destroy_subscriptions(out)
+      log out, "Removing subscriptions for all queues..."
+
+      self.each do |queue|
+        queue.destroy_subscriptions
+        log_subscriptions(out, queue)
+      end
+    end
+
+    private
+
+    def log_subscriptions(out, queue)
+      log out, "#{queue} (#{queue.redis_key}) subscriptions:"
+
+      if (subs = queue.get_subscriptions).empty?
+        log out, "\tno subscriptions"; return
+      end
+
+      event_ljust = subs.map{|event_key, handler_class| event_key.size}.max
+      subs.each do |event_key, handler_class|
+        log out, "\t#{event_key.ljust(event_ljust)} => #{handler_class}"
+      end
+    end
+
+    def log(out, msg); out.puts(msg); end
 
   end
 

--- a/lib/qs/queue.rb
+++ b/lib/qs/queue.rb
@@ -1,0 +1,267 @@
+require 'singleton'
+require 'qs/job'
+require 'qs/event'
+
+module Qs
+
+  JobNotConfiguredError   = Class.new(RuntimeError)
+  JobHandlerMissingError  = Class.new(RuntimeError)
+  JobHandlerNotFoundError = Class.new(RuntimeError)
+
+  module Queue
+
+    def self.included(klass)
+      klass.class_eval do
+        include Singleton
+        extend  ClassMethods
+      end
+      Qs.register(klass)
+    end
+
+    # map singleton methods to the class level - a friendly singleton API
+
+    module ClassMethods
+
+      # can't rely on `method_missing` - everything responds to `name`
+      define_method(:name) do |*args, &block|
+        self.instance.send(:name, *args, &block)
+      end
+
+      def respond_to?(method)
+        super || self.instance.respond_to?(method)
+      end
+
+      def method_missing(method, *args, &block)
+        self.instance.send(method, *args, &block)
+      end
+    end
+
+    attr_reader :job_handlers
+
+    def initialize
+      @job_handlers = {}
+    end
+
+    # Settings
+
+    def redis_key; "#{Qs.config.queue_key_prefix}__#{self.name}"; end
+    def logger; Qs.config.logger; end
+
+    def name(value=nil)
+      @name = value if !value.nil?
+      @name || self.class.to_s
+    end
+
+    def job_handler_ns(value=nil)
+      @job_handler_ns = value if !value.nil?
+      @job_handler_ns
+    end
+
+    def event_handler_ns(value = nil)
+      @event_handler_ns = value if !value.nil?
+      @event_handler_ns
+    end
+
+    # This defines a named job and the handler to perform it with.
+
+    def job(job_name, handler_class)
+      if self.job_handler_ns && !(handler_class =~ /^::/)
+        handler_class = "#{self.job_handler_ns}::#{handler_class}"
+      end
+      @job_handlers[job_name.to_s] = handler_class.to_s
+    end
+
+    # This defines a event and the handler to perform it with.
+
+    def event(channel, event, handler_class)
+      if self.event_handler_ns && !(handler_class =~ /^::/)
+        handler_class = "#{self.event_handler_ns}::#{handler_class}"
+      end
+
+      Event.new(channel, event).tap do |event|
+        self.subscriptions.set(event, handler_class)
+      end
+    end
+
+    # Actions
+
+    def add(job_name, args=nil)
+      handler_class = @job_handlers[job_name.to_s]
+
+      if handler_class
+        job = Job.new(self.class, handler_class, args || {})
+        self.enqueue(job)
+      else
+        raise JobNotConfiguredError, "There is no handler defined"\
+                                     "for '#{job_name}' on `#{self.class}`."
+      end
+    end
+
+    # Adapter actions
+
+    def enqueue(job)
+      raise NotImplementedError, 'use an adapter to get this behavior'
+    end
+
+    # Event subscription handling
+
+    def subscriptions
+      @subscriptions ||= Subscriptions.new(self)
+    end
+
+    def get_subscriptions;     self.subscriptions.to_hash; end
+    def sync_subscriptions;    self.subscriptions.sync;    end
+    def destroy_subscriptions; self.subscriptions.destroy; end
+    def reset_subscriptions;   self.subscriptions.reset;   end
+
+    # This utility manages a set of subscriptions for a queue and handles
+    # accessing them in redis.
+
+    class Subscriptions
+      def initialize(queue)
+        @queue_key   = queue.redis_key
+        @queue_class = queue.class.to_s
+        @platform    = Qs.config.platform
+        @version     = Qs.config.version
+
+        @queue_data  = Data.new(@queue_key)
+        reset
+      end
+
+      def reset; @hash = {}; end
+      def keys(*args);  @hash.keys(*args);  end
+      def [](*args);    @hash.[](*args);    end
+      def each(&block); @hash.each(&block); end
+      def get(event); @hash[event.key]; end
+      def set(event, handler_class); @hash[event.key] = handler_class; end
+      def rm(event); @hash.delete(event.key); end
+
+      def to_hash
+        @queue_data.subscriptions_hash
+      end
+
+      def sync
+        # set queue attributes
+        @queue_data.set_queue_class @queue_class
+        @queue_data.set_platform    @platform
+        @queue_data.set_version     @version
+
+        # make sure all current are added
+        @hash.each do |event_key, handler_class|
+          @queue_data.add_subscription(event_key, handler_class)
+          @queue_data.add_subscriber(event_key, @queue_key)
+        end
+
+        # remove any that are not needed any more
+        current_event_keys = @hash.keys
+        not_needed = @queue_data.subscription_event_keys - current_event_keys
+        not_needed.each do |event_key|
+          @queue_data.rm_subscription(event_key)
+          @queue_data.rm_subscriber(event_key, @queue_key)
+        end
+      end
+
+      def destroy
+        @queue_data.rm_queue_class
+        @queue_data.rm_platform
+        @queue_data.rm_version
+        @queue_data.rm_subscriptions
+
+        @hash.each do |event_key, handler_class|
+          @queue_data.rm_subscriber(event_key, @queue_key)
+        end
+      end
+    end
+
+    class Data
+      def initialize(queue_key)
+        @queue_root_key = "queues:#{queue_key}"
+      end
+
+      def queue_class
+        Qs.redis{ |c| c.get(queue_class_key) || '' }
+      end
+      def set_queue_class(klass)
+        Qs.redis{ |c| c.set(queue_class_key, klass.to_s) }
+      end
+      def rm_queue_class
+        Qs.redis{ |c| c.del(queue_class_key) }
+      end
+
+      def version
+        VersionNum.new(Qs.redis{ |c| c.get(version_num_key) })
+      end
+      def set_version(num)
+        Qs.redis{ |c| c.set(version_num_key, num.to_s) }
+      end
+      def rm_version
+        Qs.redis{ |c| c.del(version_num_key) }
+      end
+
+      def platform
+        Qs.redis{ |c| c.get(platform_key) || '' }
+      end
+      def set_platform(platform)
+        Qs.redis{ |c| c.set(platform_key, platform.to_s) }
+      end
+      def rm_platform
+        Qs.redis{ |c| c.del(platform_key) }
+      end
+
+      def handler_class(event_key);
+        Qs.redis{ |c| c.hget(subscriptions_key, event_key) || '' }
+      end
+
+      def subscriptions_hash
+        Qs.redis{ |c| c.hgetall(subscriptions_key) }
+      end
+      def subscription_event_keys
+        Qs.redis{ |c| c.hkeys(subscriptions_key) }
+      end
+      def rm_subscriptions
+        Qs.redis{ |c| c.del(subscriptions_key) }
+      end
+
+      def add_subscription(subscription, handler_class)
+        Qs.redis{ |c| c.hset(subscriptions_key, subscription.to_s, handler_class.to_s) }
+      end
+      def rm_subscription(subscription)
+        Qs.redis{ |c| c.hdel(subscriptions_key, subscription.to_s) }
+      end
+
+      def subscribers(event_key)
+        Qs.redis{ |c| c.smembers(event_subscribers_key(event_key)) }
+      end
+      def add_subscriber(event_key, queue_key)
+        Qs.redis{ |c| c.sadd(event_subscribers_key(event_key), queue_key.to_s) }
+      end
+      def rm_subscriber(event_key, queue_key)
+        Qs.redis{ |c| c.srem(event_subscribers_key(event_key), queue_key.to_s) }
+      end
+
+      private
+
+      def queue_class_key;   "#{@queue_root_key}:queue_class";   end
+      def version_num_key;   "#{@queue_root_key}:version";       end
+      def platform_key;      "#{@queue_root_key}:platform";      end
+      def subscriptions_key; "#{@queue_root_key}:subscriptions"; end
+
+      def event_subscribers_key(event_key)
+        "events:#{event_key}:subscribers"
+      end
+
+      class VersionNum
+        attr_reader :major, :minor, :patch, :special
+
+        def initialize(version_string)
+          @version = version_string || "0.0.0.0"
+          @major, @minor, @patch, @special = @version.split('.').map(&:to_i)
+        end
+
+        def to_s; @version.to_s; end
+      end
+    end
+
+  end
+
+end

--- a/lib/qs/redis_connection.rb
+++ b/lib/qs/redis_connection.rb
@@ -1,0 +1,20 @@
+require 'connection_pool'
+require 'redis'
+require 'redis-namespace'
+
+module Qs
+  module RedisConnection
+
+    def self.new(cfg)
+      @pool = ::ConnectionPool.new(:timeout => cfg.timeout, :size => cfg.size) do
+        ::Redis::Namespace.new(cfg.redis_ns, {
+          :redis => ::Redis.connect({
+            :url => cfg.url,
+            :driver => cfg.driver
+          })
+        })
+      end
+    end
+
+  end
+end

--- a/qs.gemspec
+++ b/qs.gemspec
@@ -18,7 +18,11 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_development_dependency("assert")
-  gem.add_dependency("SystemTimer", ["~> 1.2"])
-  gem.add_dependency("ns-options",  ["~> 1.1"])
+
+  gem.add_dependency("SystemTimer",     ["~> 1.2"])
+  gem.add_dependency("ns-options",      ["~> 1.1"])
+  gem.add_dependency('connection_pool', ["=  0.9.2"])
+  gem.add_dependency('redis',           ["~> 3.0"])
+  gem.add_dependency('redis-namespace', ["~> 1.0"])
 
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -6,3 +6,24 @@ $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 
 require 'test/support/job_handlers'
 require 'test/support/event_handlers'
+require 'test/support/queues'
+
+require 'qs'
+require 'qs/redis_connection'
+
+Qs.configure do |c|
+  c.redis.redis_ns 'qs-test'
+  c.redis.size     1
+end
+Qs.init
+
+class Assert::Context
+
+  # remove all keys added during tests (cleanup after the tests)
+  teardown_once do
+    Qs.redis do |conn|
+      conn.keys.each{ |key| conn.del(key) }
+    end
+  end
+
+end

--- a/test/support/event_handlers.rb
+++ b/test/support/event_handlers.rb
@@ -17,7 +17,7 @@ module MyTestApp::EventHandlers
   #   include Qs::EventHandler
 
   #   def init!
-  #     @redis = Qs::RedisConnection.new
+  #     @redis = Qs::RedisConnection.new(Qs.config.redis)
   #   end
 
   #   def run!

--- a/test/support/queues.rb
+++ b/test/support/queues.rb
@@ -1,0 +1,32 @@
+require 'qs/queue'
+require 'test/support/job_handlers'
+
+module MyTestApp; end
+
+class MyTestApp::TestQueue
+  include Qs::Queue
+
+  name 'test'
+  job   :some_job,     "Some::Job"
+  event :some, :event, "Some::Event"
+
+end
+
+class MyTestApp::NamespacedTestQueue
+  include Qs::Queue
+
+  name 'namespaced_test'
+  job_handler_ns 'Some'
+  event_handler_ns 'Some'
+
+  job   :some_job,      "Job"
+  job   :other_job,     "::Other::Job"
+  event :some,  :event, "Event"
+  event :other, :event, "::Other::Event"
+
+  def enqueue(job)
+    # just return the job it is supposed to enqueue since we are testing
+    job
+  end
+
+end

--- a/test/system/queue_set_actions_tests.rb
+++ b/test/system/queue_set_actions_tests.rb
@@ -1,0 +1,114 @@
+require 'assert'
+require 'qs/queue'
+
+# These system tests ensure the action methods on a QueueSet correctly manage
+# the persisted subscriptions for all the queues in the set.
+
+class QueueSetActionsTests < Assert::Context
+  desc "the QueueSet action"
+  setup do
+    @queues = Qs.queues
+    @output = Output.new
+
+    # sync and clear output messages to start with a known state
+    @queues.sync_subscriptions(@output)
+    @output.msgs.clear
+  end
+
+  def subscriptions_msg(queue); "#{queue} (#{queue.redis_key}) subscriptions:"; end
+  def assert_msg_outputted(msg); assert_includes msg, @output.normalized_msgs; end
+
+  class Output
+    attr_reader :msgs
+    def initialize; @msgs = [];      end
+    def puts(msg);  @msgs.push(msg); end
+    def normalized_msgs
+      # clean the messages of any extra spaces, they get in the way when
+      # comparing actual and expected strings
+      @msgs.map{|m| m.gsub(/\s+/, ' ').strip}
+    end
+  end
+
+  class ListActionTests < QueueSetActionsTests
+    desc "for listing subscriptions"
+    setup do
+      @queues.list_subscriptions(@output)
+    end
+
+    should "output queue subscriptions" do
+      @queues.first.tap do |queue|
+        assert_msg_outputted subscriptions_msg(queue)
+        queue.subscriptions.keys.first.tap do |event_key|
+          handler_class = queue.subscriptions[event_key]
+          assert_msg_outputted "#{event_key} => #{handler_class}"
+        end
+      end
+    end
+
+  end
+
+  class SyncActionTests < QueueSetActionsTests
+    desc "for syncing subscriptions"
+    setup do
+      @queues.sync_subscriptions(@output)
+    end
+
+    should "output that it is syncing subscriptions for all queues" do
+      assert_msg_outputted "Syncing subscriptions for all queues..."
+    end
+
+    should "run the list task" do
+      @queues.each{|q| assert_msg_outputted subscriptions_msg(q)}
+    end
+
+    should "store the queue subscriptions in redis" do
+      @queues.first.tap do |queue|
+        queue_data = Qs::Queue::Data.new(queue.redis_key)
+
+        assert_equal queue.to_s,         queue_data.queue_class
+        assert_equal Qs.config.platform, queue_data.platform
+        assert_equal Qs.config.version,  queue_data.version.to_s
+
+        queue.subscriptions.keys.first.tap do |event_key|
+          handler_class = queue.subscriptions[event_key]
+          assert_equal    handler_class,   queue_data.handler_class(event_key)
+          assert_includes queue.redis_key, queue_data.subscribers(event_key)
+        end
+      end
+    end
+
+  end
+
+  class DestroyActionTests < QueueSetActionsTests
+    desc "for removing subscriptions"
+    setup do
+      @queues.destroy_subscriptions(@output)
+    end
+
+    should "output that it is syncing subscriptions for all queues" do
+      assert_msg_outputted "Removing subscriptions for all queues..."
+    end
+
+    should "run the list task" do
+      @queues.each{|q| assert_msg_outputted subscriptions_msg(q)}
+    end
+
+    should "have removed the queues configuration from redis" do
+      @queues.first.tap do |queue|
+        queue_data = Qs::Queue::Data.new(queue.redis_key)
+
+        assert_not_equal queue.to_s,         queue_data.queue_class
+        assert_not_equal Qs.config.platform, queue_data.platform
+        assert_not_equal Qs.config.version,  queue_data.version.to_s
+
+        queue.subscriptions.keys.first.tap do |event_key|
+          handler_class = queue.subscriptions[event_key]
+          assert_not_equal    handler_class,   queue_data.handler_class(event_key)
+          assert_not_includes queue.redis_key, queue_data.subscribers(event_key)
+        end
+      end
+    end
+
+  end
+
+end

--- a/test/unit/qs_tests.rb
+++ b/test/unit/qs_tests.rb
@@ -1,5 +1,6 @@
 require 'assert'
 require 'qs'
+require 'qs/redis_connection'
 
 module Qs
 
@@ -7,10 +8,27 @@ module Qs
     desc "the Qs module"
     subject { Qs }
 
-    should have_imeths :config, :configure, :init
+    should have_imeths :config, :configure, :init, :after_fork
+    should have_imeths :queues, :register, :redis
 
     should "know its config singleton" do
       assert_same Config, subject.config
+    end
+
+    should "add a queue to it's set with #register" do
+      test_queue = Class.new
+      subject.register(test_queue)
+
+      assert_includes test_queue, subject.queues
+
+      subject.queues.delete(test_queue)
+    end
+
+    should "complain if accessing the redis connection without a block" do
+      assert_raises(ArgumentError){ subject.redis }
+      assert_nothing_raised do
+        subject.redis{|conn| }
+      end
     end
 
     # Note: don't really need to explicitly test the configure/init meths
@@ -22,7 +40,7 @@ module Qs
     desc "the Qs Config singleton"
     subject { Config }
 
-    should have_imeths :timeout, :logger
+    should have_imeths :queue_key_prefix, :timeout, :logger
     should have_imeths :default_timeout, :null_logger
 
     should "know its default_timeout" do
@@ -33,12 +51,32 @@ module Qs
       assert_kind_of ::Logger, subject.null_logger
     end
 
+    should "set a default queue_key_prefix" do
+      assert_equal 'qs', subject.queue_key_prefix
+    end
+
     should "use its default timeout for its timeout setting (by default)" do
       assert_equal subject.default_timeout, subject.timeout
     end
 
     should "use its null logger for its logger setting (by default)" do
       assert_same subject.null_logger, subject.logger
+    end
+
+  end
+
+  class RedisConfigTests < ConfigTests
+    desc "redis configs"
+    subject { Config.redis }
+
+    should have_imeths :url, :ns, :size, :timeout, :driver
+
+    should "know its redis config values" do
+      assert_equal 'redis://localhost:6379/0', subject.url
+      assert_equal 'qs-test', subject.redis_ns
+      assert_equal 1, subject.size
+      assert_equal 1, subject.timeout
+      assert_equal 'ruby', subject.driver
     end
 
   end

--- a/test/unit/queue_tests.rb
+++ b/test/unit/queue_tests.rb
@@ -1,0 +1,172 @@
+require 'assert'
+require 'qs/event'
+require 'qs/queue'
+
+module Qs::Queue
+
+  class BaseTests < Assert::Context
+    desc "Qs::Queue"
+    subject{ MyTestApp::TestQueue }
+
+    should have_readers :job_handlers
+    should have_imeths  :redis_key, :logger, :name
+    should have_imeths  :job_handler_ns, :event_handler_ns
+    should have_imeths  :job, :add, :enqueue
+    should have_imeths  :subscriptions, :get_subscriptions, :sync_subscriptions
+    should have_imeths  :destroy_subscriptions, :reset_subscriptions
+
+    should "be a Singleton" do
+      assert_includes Singleton, subject.included_modules
+    end
+
+    should "have added the queue to I-Resque known queues" do
+      assert_includes subject, Qs.queues
+    end
+
+    should "have set it's name" do
+      assert_equal 'test', subject.name
+    end
+
+    should "use the queue_key_prefix and its name to build its redis key" do
+      assert_equal 'qs__test', subject.redis_key
+    end
+
+    should "add a handler mapping with the `job` method" do
+      subject.job('test_job', 'TestJob')
+      assert_equal 'TestJob', subject.job_handlers['test_job']
+    end
+
+    should "raise not implemented if `enqueue` has not been overwritten" do
+      assert_raises(NotImplementedError){ subject.enqueue('a_job') }
+    end
+
+    should "create an return an Event using its params" do
+      event = subject.event(:some, :event, "TestEvent")
+
+      assert event
+      assert_instance_of Qs::Event, event
+      assert_equal 'some',  event.channel
+      assert_equal 'event', event.name
+
+      stored_handler_class = subject.subscriptions.get(event)
+      assert_equal "TestEvent", stored_handler_class
+    end
+
+  end
+
+  class JobWithNamespaceTests < BaseTests
+    desc "job method with a defined job_handler_ns"
+    subject{ MyTestApp::NamespacedTestQueue }
+
+    should "add a handler mapping using the ns" do
+      subject.job('namespaced_test_job', 'TestJob')
+      assert_equal 'Some::TestJob', subject.job_handlers['namespaced_test_job']
+    end
+
+    should "ignore the ns when the handler class has leading colons" do
+      subject.job('test_job', '::TestJob')
+      assert_equal '::TestJob', subject.job_handlers['test_job']
+    end
+
+  end
+
+  class EventWithNamespaceTests < BaseTests
+    desc "event method with a defined event_handler_ns"
+    subject{ MyTestApp::NamespacedTestQueue }
+
+    should "add an event mapping using the event_handler_ns" do
+      event = subject.event(:namespaced, :test_event, 'TestEvent')
+
+      stored_handler = subject.subscriptions.get(event)
+      assert_equal 'Some::TestEvent', stored_handler
+    end
+
+    should "ignore the handler ns when the handler class has leading colons" do
+      event = subject.event(:other, :test_event, '::TestEvent')
+
+      stored_handler = subject.subscriptions.get(event)
+      assert_equal '::TestEvent', stored_handler
+    end
+
+  end
+
+  class SyncTests < BaseTests
+    desc "sync"
+    setup do
+      @queue_data  = Data.new(subject.redis_key)
+      @some_event  = subject.event(:some_sync_test,  :event, 'SomeEvent')
+      @other_event = subject.event(:other_sync_test, :event, 'OtherEvent')
+      subject.sync_subscriptions
+    end
+    teardown do
+      subject.subscriptions.rm(@some_event)
+      subject.subscriptions.rm(@other_event)
+      subject.sync_subscriptions
+    end
+
+    should "store the subscriptions in redis" do
+      assert_equal 'MyTestApp::TestQueue', @queue_data.queue_class
+      assert_equal 'ruby', @queue_data.platform
+      assert_equal Qs::VERSION, @queue_data.version.to_s
+
+      some_event_subscribers  = @queue_data.subscribers(@some_event.key)
+      other_event_subscribers = @queue_data.subscribers(@other_event.key)
+
+      assert_includes @some_event.key,  @queue_data.subscriptions_hash.keys
+      assert_includes @other_event.key, @queue_data.subscriptions_hash.keys
+      assert_includes 'qs__test', some_event_subscribers
+      assert_includes 'qs__test', other_event_subscribers
+    end
+
+  end
+
+  class SyncWithRemovalsTests < SyncTests
+    desc "with removals"
+    setup do
+      subject.subscriptions.rm(@other_event)
+      @another_event = subject.event(:another_sync_test, :event, 'AnotherEvent')
+      subject.sync_subscriptions
+    end
+    teardown do
+      subject.subscriptions.rm(@other_event)
+      subject.sync_subscriptions
+    end
+
+    should "sync subscriptions by adding new ones and removing old ones" do
+      another_event_subscribers = @queue_data.subscribers(@another_event.key)
+      other_event_subscribers   = @queue_data.subscribers(@other_event.key)
+
+      assert_includes @another_event.key, @queue_data.subscriptions_hash.keys
+      assert_not_includes @other_event.key, @queue_data.subscriptions_hash.keys
+      assert_includes     'qs__test', another_event_subscribers
+      assert_not_includes 'qs__test', other_event_subscribers
+    end
+
+  end
+
+  class DestroyTests < SyncTests
+    desc "then destroy"
+    setup do
+      subject.destroy_subscriptions
+    end
+    teardown do
+      subject.sync_subscriptions
+    end
+
+    should "destroy all the subscriptions in redis" do
+      assert_not_equal 'TestQueue', @queue_data.queue_class
+      assert_not_equal 'ruby',      @queue_data.platform
+      assert_not_equal Qs::VERSION, @queue_data.version.to_s
+
+      assert_equal Hash.new, @queue_data.subscriptions_hash
+
+      some_event_subscribers  = @queue_data.subscribers(@some_event.key)
+      other_event_subscribers = @queue_data.subscribers(@other_event.key)
+
+      assert_not_includes 'i-events__test', some_event_subscribers
+      assert_not_includes 'i-events__test', other_event_subscribers
+    end
+
+  end
+
+end


### PR DESCRIPTION
Mixin on a class to define a queue. This includes all generic
queue behavior: defining jobs/events, subscription management
(including persisting to redis).

With this you can define as many queues as you'd like and defing
the jobs/events they process.

/cc @jcredding 
