### PR TITLE
Add a `qs` bin and `CLI` class for it's logic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gemspec
 
 gem 'rake'
+gem 'pry'

--- a/bin/qs
+++ b/bin/qs
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+#
+# Copyright (c) 2013 Collin Redding & Kelly Redding
+#
+
+require 'qs/cli'
+Qs::CLI.run ARGV

--- a/lib/qs/cli.rb
+++ b/lib/qs/cli.rb
@@ -1,0 +1,105 @@
+module Qs
+
+  class CLI
+
+    def self.run(*args)
+      self.new.run(*args)
+    end
+
+    def initialize
+      @cli = CLIRB.new do
+        # TODO - port, queue name, number of threads, etc...
+      end
+    end
+
+    def run(*args)
+      begin
+        run!(*args)
+      rescue CLIRB::HelpExit
+        puts help
+      rescue CLIRB::VersionExit
+        puts Qs::VERSION
+      rescue CLIRB::Error => exception
+        puts "#{exception.message}\n\n"
+        puts help
+        exit(1)
+      rescue Exception => exception
+        puts "#{exception.class}: #{exception.message}"
+        puts exception.backtrace.join("\n") if ENV['DEBUG']
+        exit(1)
+      end
+      exit(0)
+    end
+
+    def help
+      "Usage: qs <config file> <command> <options> \n" \
+      "Commands: run, start, stop, restart \n" \
+      "#{@cli}"
+    end
+
+    private
+
+    def run!(*args)
+      @cli.parse!(*args)
+      # config_file = Qs::ConfigFile.new(*@cli.args)
+      # Qs::Process.run(config_file.daemon)
+    end
+
+  end
+
+  class CLIRB  # Version 1.0.0, https://github.com/redding/cli.rb
+    Error    = Class.new(RuntimeError);
+    HelpExit = Class.new(RuntimeError); VersionExit = Class.new(RuntimeError)
+    attr_reader :argv, :args, :opts, :data
+
+    def initialize(&block)
+      @options = []; instance_eval(&block) if block
+      require 'optparse'
+      @data, @args, @opts = [], [], {}; @parser = OptionParser.new do |p|
+        p.banner = ''; @options.each do |o|
+          @opts[o.name] = o.value; p.on(*o.parser_args){ |v| @opts[o.name] = v }
+        end
+        p.on_tail('--version', ''){ |v| raise VersionExit, v.to_s }
+        p.on_tail('--help',    ''){ |v| raise HelpExit,    v.to_s }
+      end
+    end
+
+    def option(*args); @options << Option.new(*args); end
+    def parse!(argv)
+      @args = (argv || []).dup.tap do |args_list|
+        begin; @parser.parse!(args_list)
+        rescue OptionParser::ParseError => err; raise Error, err.message; end
+      end; @data = @args + [@opts]
+    end
+    def to_s; @parser.to_s; end
+    def inspect
+      "#<#{self.class}:#{'0x0%x' % (object_id << 1)} @data=#{@data.inspect}>"
+    end
+
+    class Option
+      attr_reader :name, :opt_name, :desc, :abbrev, :value, :klass, :parser_args
+
+      def initialize(name, *args)
+        settings, @desc = args.last.kind_of?(::Hash) ? args.pop : {}, args.pop || ''
+        @name, @opt_name, @abbrev = parse_name_values(name, settings[:abbrev])
+        @value, @klass = gvalinfo(settings[:value])
+        @parser_args = if [TrueClass, FalseClass, NilClass].include?(@klass)
+          ["-#{@abbrev}", "--[no-]#{@opt_name}", @desc]
+        else
+          ["-#{@abbrev}", "--#{@opt_name} #{@opt_name.upcase}", @klass, @desc]
+        end
+      end
+
+      private
+
+      def parse_name_values(name, custom_abbrev)
+        [ (processed_name = name.to_s.strip.downcase), processed_name.gsub('_', '-'),
+          custom_abbrev || processed_name.gsub(/[^a-z]/, '').chars.first || 'a'
+        ]
+      end
+      def gvalinfo(v); v.kind_of?(Class) ? [nil,gklass(v)] : [v,gklass(v.class)]; end
+      def gklass(k); k == Fixnum ? Integer : k; end
+    end
+  end
+
+end

--- a/qs.gemspec
+++ b/qs.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_development_dependency("assert")
-  # TODO: gem.add_dependency("gem-name", ["~> 0.0"])
+  gem.add_development_dependency("assert-mocha")
 
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -4,4 +4,5 @@
 # add the root dir to the load path
 $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 
-# TODO: put test helpers here...
+require 'pry' # require pry for debugging (`binding.pry`)
+require 'assert-mocha' if defined?(Assert)

--- a/test/support/config.qs
+++ b/test/support/config.qs
@@ -1,0 +1,5 @@
+require 'qs'
+
+# TODO
+# run Qs::Daemon.new(MyQueue)
+run 'test'

--- a/test/unit/cli_tests.rb
+++ b/test/unit/cli_tests.rb
@@ -1,0 +1,109 @@
+require 'assert'
+require 'qs/cli'
+
+class Qs::CLI
+
+  class BaseTests < Assert::Context
+    desc "Qs::CLI"
+    setup_once do
+      Qs::CLI.class_eval{ include Spy }
+    end
+    setup do
+      @cli = Qs::CLI.new
+    end
+    subject{ @cli }
+
+    should have_imeths :run, :help
+    should have_cmeths :run
+
+    should "return a help message with #help" do
+      expected = "Usage: qs <config file> <command> <options> \n" \
+                 "Commands: run, start, stop, restart \n\n" \
+                 "        --version\n" \
+                 "        --help\n"
+      assert_equal expected, subject.help
+    end
+
+  end
+
+  class RunHelpTests < BaseTests
+    desc "with the --help switch"
+    setup do
+      @cli.run([ "--help" ])
+    end
+
+    should "print out the help output and exit with a 0" do
+      assert_equal subject.help, subject.puts_messages[0]
+      assert_equal 0, subject.exit_status_code
+    end
+
+  end
+
+  class RunVersionTests < BaseTests
+    desc "with the --version switch"
+    setup do
+      @cli.run([ "--version" ])
+    end
+
+    should "print out the version and exit with a 0" do
+      assert_equal Qs::VERSION, subject.puts_messages[0]
+      assert_equal 0, subject.exit_status_code
+    end
+
+  end
+
+  class OnCLIErrorTests < BaseTests
+    desc "on a CLI error"
+    setup do
+      @exception = Qs::CLIRB::Error.new("no config file")
+      @cli.stubs(:run!).raises(@exception)
+      @cli.run
+    end
+
+    should "print out the exception message, the help and exit with a 1" do
+      assert_equal "#{@exception.message}\n\n", subject.puts_messages[0]
+      assert_equal subject.help, subject.puts_messages[1]
+      assert_equal 1, subject.exit_status_code
+    end
+
+  end
+
+  class AllOtherExceptionsTests < BaseTests
+    desc "when other uncaught exceptions occur"
+    setup do
+      @current_debug = ENV['DEBUG']
+      ENV['DEBUG'] = 'yes'
+      @exception = StandardError.new("something went wrong")
+      @cli.stubs(:run!).raises(@exception)
+      @cli.run
+    end
+    teardown do
+      ENV['DEBUG'] = @current_debug
+    end
+
+    should "print out the exception message, backtrace and exit with a 1" do
+      expected = "#{@exception.class}: #{@exception.message}"
+      assert_equal expected, subject.puts_messages[0]
+      expected = @exception.backtrace.join("\n")
+      assert_equal expected, subject.puts_messages[1]
+      assert_equal 1, subject.exit_status_code
+    end
+
+  end
+
+  module Spy
+
+    attr_reader :exit_status_code, :puts_messages
+
+    def puts(message)
+      @puts_messages ||= []
+      @puts_messages << message
+    end
+
+    def exit(status_code)
+      @exit_status_code ||= status_code
+    end
+
+  end
+
+end


### PR DESCRIPTION
This adds a `qs` bin and a `CLI` for it's logic. This is intended
for starting a qs daemon that will process background jobs. It
uses CLIRB and layers on it's own behavior. This is mostly just
a starting point to work from and will be built on as the daemon
process logic is built out.
