### PR TITLE
Add a `Process` class for managing Qs daemon processes

### DIFF
--- a/lib/qs/cli.rb
+++ b/lib/qs/cli.rb
@@ -1,4 +1,5 @@
 require 'qs/daemon'
+require 'qs/process'
 
 module Qs
 
@@ -21,7 +22,7 @@ module Qs
         puts help
       rescue CLIRB::VersionExit
         puts Qs::VERSION
-      rescue Qs::Config::InvalidError, CLIRB::Error => exception
+      rescue Qs::Process::InvalidError, Qs::Config::InvalidError, CLIRB::Error => exception
         puts "#{exception.message}\n\n"
         puts help
         exit(1)
@@ -46,7 +47,7 @@ module Qs
       command          = @cli.args.pop || 'run'
       config_file_path = @cli.args.pop || 'config.qs'
       daemon = Qs::Config.parse(config_file_path).daemon
-      # Qs::Process.call(command, daemon)
+      Qs::Process.call(command, daemon)
     end
 
   end

--- a/lib/qs/daemon.rb
+++ b/lib/qs/daemon.rb
@@ -2,6 +2,91 @@ module Qs
 
   class Daemon
 
+    # This is all temporary
+    attr_accessor :queue_name, :logger, :pid_file, :redis_ip, :redis_port
+    attr_accessor :thread, :state
+
+    def initialize
+      set_state :init
+      @signal_queue ||= []
+    end
+
+    def run
+      set_state :run
+      @thread = Thread.new do
+        loop do
+          break if !@state.run?
+          sleep 0.5
+          handle_signal(@signal_queue.pop) unless @signal_queue.empty?
+        end
+      end
+    end
+
+    def join_thread
+      @thread.join
+    end
+
+    def signal_stop
+      @signal_queue << :stop
+    end
+
+    def signal_halt
+      @signal_queue << :halt
+    end
+
+    def signal_restart
+      @signal_queue << :restart
+    end
+
+    def running?
+      @thread && @thread.alive?
+    end
+
+    def in_stop_state?
+      @state.stop?
+    end
+
+    def in_halt_state?
+      @state.halt?
+    end
+
+    def in_restart_state?
+      @state.restart?
+    end
+
+    private
+
+    def handle_signal(signal)
+      set_state(signal)
+    end
+
+    def set_state(name)
+      @state = State.new(name)
+    end
+
+    class State
+      def initialize(name)
+        @name = name.to_sym
+        # TODO - validation
+      end
+
+      def run?
+        @name == :run
+      end
+
+      def restart?
+        @name == :restart
+      end
+
+      def stop?
+        @name == :stop
+      end
+
+      def halt?
+        @name == :halt
+      end
+    end
+
   end
 
 end

--- a/lib/qs/process.rb
+++ b/lib/qs/process.rb
@@ -1,0 +1,183 @@
+require 'fileutils'
+
+module Qs
+
+  class Process
+
+    InvalidError = Class.new(StandardError)
+
+    def self.call(command, daemon)
+      self.new(daemon).call(command)
+    end
+
+    def initialize(daemon)
+      @daemon = daemon
+    end
+
+    def call(command)
+      case command.to_sym
+      when :run
+        DaemonHandler.run(@daemon, false)
+      when :start
+        DaemonHandler.run(@daemon, true)
+      when :stop
+        Signal.send("TERM", @daemon)
+      when :restart
+        Signal.send("USR2", @daemon)
+      else
+        raise InvalidError, "Unknown command: #{command.inspect}"
+      end
+    end
+
+    class DaemonHandler
+      def self.run(daemon, daemonize_process)
+        self.new(daemon).run(daemonize_process)
+      end
+
+      def initialize(daemon)
+        @daemon       = daemon
+        @queue_name   = @daemon.queue_name
+        @logger       = @daemon.logger
+        @process_name = ProcessName.new(@daemon)
+        @pid_file     = PIDFile.new(@daemon.pid_file)
+        @restart_cmd  = RestartCmd.new
+      end
+
+      def run(daemonize = false)
+        daemonize!(true) if daemonize && !ENV['QS_SKIP_DAEMONIZE']
+        log "Starting Qs daemon for #{@queue_name}..."
+        $0 = @process_name
+        @pid_file.write
+        log "PID: #{::Process.pid}"
+
+        ::Signal.trap("TERM"){ @daemon.signal_stop }
+        ::Signal.trap("INT"){  @daemon.signal_halt }
+        ::Signal.trap("USR2"){ @daemon.signal_restart }
+
+        @daemon.run
+        log "#{@queue_name} daemon started and ready."
+        @daemon.join_thread
+        restart if @daemon.in_restart_state?
+      rescue RuntimeError => exception
+        log "Error: #{exception.message}"
+        log "#{@queue_name} daemon never started."
+      ensure
+        @pid_file.remove
+      end
+
+      private
+
+      def log(message)
+        @logger.info "[Qs] #{message}"
+      end
+
+      def restart
+        log "Restarting #{@queue_name} daemon..."
+        ENV['QS_SKIP_DAEMONIZE'] = 'yes'
+        Dir.chdir @restart_cmd.dir
+        Kernel.exec(*@restart_cmd.argv)
+      end
+
+      # Full explanation: http://www.steve.org.uk/Reference/Unix/faq_2.html#SEC16
+      def daemonize!(no_chdir = false, no_close = false)
+        exit if fork
+        Process.setsid
+        exit if fork
+        Dir.chdir "/" unless no_chdir
+        if !no_close
+          null = File.open "/dev/null", 'w'
+          STDIN.reopen null
+          STDOUT.reopen null
+          STDERR.reopen null
+        end
+        return 0
+      end
+    end
+
+    class Signal
+      def self.send(signal, daemon)
+        self.new(signal, daemon).send
+      end
+
+      def initialize(signal, daemon)
+        @signal   = signal
+        @daemon   = daemon
+        @pid_file = PIDFile.new(@daemon.pid_file)
+      end
+
+      def send
+        ::Process.kill(@signal, @pid_file.pid)
+      end
+    end
+
+    class PIDFile
+      attr_reader :path
+
+      def initialize(path)
+        @path = (path || '/dev/null').to_s
+      end
+
+      def pid
+        pid = File.read(@path).strip
+        pid && !pid.empty? ? pid.to_i : raise('no pid in file')
+      rescue Exception => exception
+        error = InvalidError.new("A PID couldn't be read from #{@path.inspect}")
+        error.set_backtrace(exception.backtrace)
+        raise error
+      end
+
+      def write
+        begin
+          FileUtils.mkdir_p(File.dirname(@path))
+          File.open(@path, 'w'){ |f| f.puts ::Process.pid }
+        rescue Exception => exception
+          error = InvalidError.new("Can't write pid to file #{@path.inspect}")
+          error.set_backtrace(exception.backtrace)
+          raise error
+        end
+      end
+
+      def remove
+        FileUtils.rm_f(@path)
+      end
+
+      def to_s
+        @path
+      end
+    end
+
+    class ProcessName < String
+      def initialize(daemon)
+        super "qs_#{daemon.queue_name}_#{daemon.redis_ip}_#{daemon.redis_port}"
+      end
+    end
+
+    class RestartCmd
+      attr_reader :argv, :dir
+
+      def initialize
+        require 'rubygems'
+        @dir  = get_pwd
+        @argv = [ Gem.ruby, $0, ARGV.dup ].flatten
+      end
+
+      protected
+
+      # Trick from puma/unicorn. Favor PWD because it contains an unresolved
+      # symlink. This is useful when restarting after deploying; the original
+      # directory may be removed, but the symlink is pointing to a new
+      # directory.
+      def get_pwd
+        env_stat = File.stat(ENV['PWD'])
+        pwd_stat = File.stat(Dir.pwd)
+        if env_stat.ino == pwd_stat.ino && env_stat.dev == pwd_stat.dev
+          ENV['PWD']
+        else
+          Dir.pwd
+        end
+      end
+    end
+
+  end
+
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,4 +8,5 @@ require 'pry' # require pry for debugging (`binding.pry`)
 require 'assert-mocha' if defined?(Assert)
 
 require 'pathname'
-SUPPORT_PATH = Pathname.new(File.expand_path('../support', __FILE__))
+ROOT         = Pathname.new(File.expand_path('../..', __FILE__))
+SUPPORT_PATH = ROOT.join('test/support')

--- a/test/support/spy.rb
+++ b/test/support/spy.rb
@@ -1,0 +1,88 @@
+class Spy
+
+  def initialize(subject)
+    @subject = subject
+    @subject_metaclass = (class << @subject; self; end)
+    @metaclass         = (class << self; self; end)
+    @tracked_methods          = {}
+    @tracked_instance_methods = {}
+  end
+
+  def method(name)
+    @tracked_methods[name.to_s]
+  end
+
+  def instance_method(name)
+    @tracked_instance_methods[name.to_s]
+  end
+
+  def track(name)
+    @tracked_methods[name.to_s] = Method.new(name).tap do |m|
+      m.add_to(@subject_metaclass)
+    end
+    true
+  end
+
+  def ignore(name)
+    @tracked_methods.delete(name.to_s).tap do |m|
+      m.remove_from(@subject_metaclass)
+    end
+    true
+  end
+
+  def track_on_instance(name)
+    @tracked_instance_methods[name.to_s] = Method.new(name).tap do |m|
+      m.add_to(@subject)
+    end
+    true
+  end
+
+  def ignore_on_instance(name)
+    @tracked_instance_methods.delete(name.to_s).tap do |m|
+      m.remove_from(@subject)
+    end
+    true
+  end
+
+  class Method
+    attr_reader :name, :original_method_name, :calls
+
+    def initialize(name)
+      @name = name
+      @original_method_name = "__spy_original_#{@name}__"
+      @calls = []
+    end
+
+    def called(*args, &block)
+      @calls << MethodCall.new(@name, args, block)
+    end
+
+    def add_to(object)
+      method = self
+      object.class_eval do
+
+        alias_method method.original_method_name, method.name
+
+        define_method(method.name) do |*args, &block|
+          method.called(*args, &block)
+          # TODO - allow passing through, on/off
+        end
+
+      end
+    end
+
+    def remove_from(object)
+      method = self
+      object.class_eval do
+
+        remove_method method.name
+
+        alias_method method.name, method.original_method_name
+
+      end
+    end
+  end
+
+  MethodCall = Struct.new(:name, :args, :block)
+
+end

--- a/test/unit/process_tests.rb
+++ b/test/unit/process_tests.rb
@@ -1,0 +1,267 @@
+require 'assert'
+require 'qs/process'
+
+require 'qs/daemon'
+require 'logger'
+require 'thread'
+require 'test/support/spy'
+
+class Qs::Process
+
+  class UnitTests < Assert::Context
+    desc "Qs::Process"
+    setup do
+      @daemon = Qs::Daemon.new
+      @daemon.queue_name = "test__main"
+      @daemon.logger     = Logger.new(File.open(ROOT.join("log/test.log"), 'w'))
+      @daemon.pid_file   = ROOT.join("tmp/test.pid")
+      @daemon.redis_ip   = "0.0.0.0"
+      @daemon.redis_port = 1234
+      @process = Qs::Process.new(@daemon)
+    end
+    subject{ @process }
+
+    should have_imeths :call
+    should have_cmeths :call
+
+    should "raise an unknown command error when " \
+           "passing an unexpected command string to #call" do
+      exception = nil
+      begin; @process.call('invalid'); rescue Exception => exception; end
+      assert_instance_of Qs::Process::InvalidError, exception
+      assert_equal "Unknown command: \"invalid\"", exception.message
+    end
+
+  end
+
+  class RunningADaemonTests < UnitTests
+    setup do
+      @signal_spy  = Spy.new(::Signal).tap{ |s| s.track(:trap) }
+      @dir_spy     = Spy.new(::Dir).tap{ |s| s.track(:chdir) }
+      @kernel_spy  = Spy.new(::Kernel).tap{ |s| s.track(:exec) }
+      @handler_spy = Spy.new(Qs::Process::DaemonHandler).tap do |s|
+        s.track_on_instance(:daemonize!)
+      end
+      @current_qs_skip_daemonize = ENV['QS_SKIP_DAEMONIZE']
+      @current_process_name = $0
+    end
+    teardown do
+      $0 = @current_process_name
+      ENV['QS_SKIP_DAEMONIZE'] = @current_qs_skip_daemonize
+      @handler_spy.ignore_on_instance(:daemonize!)
+      @kernel_spy.ignore(:exec)
+      @dir_spy.ignore(:chdir)
+      @signal_spy.ignore(:trap)
+    end
+
+    private
+
+    def call_in_thread(command)
+      @process_thread = Thread.new do
+        begin
+          @process.call(command)
+        rescue Exception => exception
+          if ENV['DEBUG']
+            puts exception.inspect
+            puts exception.backtrace.join("\n")
+          end
+        end
+      end
+      @process_thread.abort_on_exception = false
+      @process_thread.join(0.1)
+      @process_thread
+    end
+
+    def shutdown_thread
+      if @process_thread && @process_thread.alive?
+        @daemon.signal_stop
+        @process_thread.join
+      end
+    end
+
+  end
+
+  class CallRunTests < RunningADaemonTests
+    desc "calling the 'run' command"
+    setup do
+      call_in_thread('run')
+    end
+    teardown do
+      shutdown_thread
+    end
+
+    should "set the process name" do
+      assert_equal "qs_test__main_0.0.0.0_1234", $0
+    end
+
+    should "have written the PID file" do
+      assert File.exists?(@daemon.pid_file)
+    end
+
+    should "remove the PID file when it exits" do
+      @daemon.signal_stop
+      @process_thread.join
+      assert_not File.exists?(@daemon.pid_file)
+    end
+
+    should "remove the PID file even when an exception occurs" do
+      @process_thread.raise("something went wrong")
+      @process_thread.join
+      assert_not File.exists?(@daemon.pid_file)
+    end
+
+    should "run the daemon without daemonizing the process" do
+      assert @daemon.running?
+      assert_empty @handler_spy.instance_method(:daemonize!).calls
+    end
+
+    should "trap the TERM signal and stop the daemon when triggered" do
+      trap_call = @signal_spy.method(:trap).calls[0]
+      assert_equal "TERM", trap_call.args[0]
+
+      trap_call.block.call
+      @process_thread.join
+      assert @daemon.in_stop_state?
+      assert_not @daemon.running?
+    end
+
+    should "trap the INT signal and halt the daemon when triggered" do
+      trap_call = @signal_spy.method(:trap).calls[1]
+      assert_equal "INT", trap_call.args[0]
+
+      trap_call.block.call
+      @process_thread.join
+      assert @daemon.in_halt_state?
+      assert_not @daemon.running?
+    end
+
+    should "trap the USR2 signal and restart the process when triggered" do
+      trap_call = @signal_spy.method(:trap).calls[2]
+      assert_equal "USR2", trap_call.args[0]
+
+      trap_call.block.call
+      @process_thread.join
+      assert @daemon.in_restart_state?
+      assert_not @daemon.running?
+
+      # should have restarted the current process
+      chdir_call = @dir_spy.method(:chdir).calls[0]
+      exec_call  = @kernel_spy.method(:exec).calls[0]
+      assert_equal 'yes', ENV['QS_SKIP_DAEMONIZE']
+      assert_equal ENV['PWD'], chdir_call.args[0]
+      expected = [ Gem.ruby, @current_process_name, ARGV.dup ].flatten
+      assert expected, exec_call.args[0]
+    end
+
+  end
+
+  class CallStartTests < RunningADaemonTests
+    desc "calling the 'start' command"
+    setup do
+      call_in_thread('start')
+    end
+    teardown do
+      shutdown_thread
+    end
+
+    should "daemonize the process and run the daemon" do
+      assert_not_empty @handler_spy.instance_method(:daemonize!).calls
+      assert @daemon.running?
+    end
+
+  end
+
+  class CallStartWithSkipDaemonizeTests < RunningADaemonTests
+    desc "calling the 'start' command with QS_SKIP_DAEMONIZE set"
+    setup do
+      ENV['QS_SKIP_DAEMONIZE'] = 'yes'
+      call_in_thread('start')
+    end
+    teardown do
+      shutdown_thread
+    end
+
+    should "run the daemon without daemonizing the process" do
+      assert @daemon.running?
+      assert_empty @handler_spy.instance_method(:daemonize!).calls
+    end
+
+  end
+
+  class RunThatCantWritePIDTests < RunningADaemonTests
+    desc "running the daemon when it can't write the PID file"
+    setup do
+      File.stubs(:open).raises("cant open file")
+    end
+    teardown do
+      File.unstub(:open)
+    end
+
+    should "raise an error about not being able to write the PID file" do
+      exception = nil
+      begin; @process.call('run'); rescue Exception => exception; end
+      assert_instance_of Qs::Process::InvalidError, exception
+      expected = "Can't write pid to file #{@daemon.pid_file.to_s.inspect}"
+      assert_equal expected, exception.message
+    end
+
+  end
+
+  class SendingASignalTests < UnitTests
+    setup do
+      File.open(@daemon.pid_file, 'w'){ |f| f.puts ::Process.pid }
+      @process_spy = Spy.new(::Process).tap{ |s| s.track(:kill) }
+    end
+    teardown do
+      FileUtils.rm_rf(@daemon.pid_file)
+    end
+  end
+
+  class CallStopTests < SendingASignalTests
+    desc "calling the 'stop' command"
+    setup do
+      @process.call('stop')
+    end
+
+    should "have sent a TERM signal to the daemon's PID" do
+      kill_call = @process_spy.method(:kill).calls.first
+      assert_equal "TERM",        kill_call.args[0]
+      assert_equal ::Process.pid, kill_call.args[1]
+    end
+
+  end
+
+  class CallRestartTests < SendingASignalTests
+    desc "calling the 'restart' command"
+    setup do
+      @process.call('restart')
+    end
+
+    should "have sent a USR2 signal to the daemon's PID" do
+      kill_call = @process_spy.method(:kill).calls.first
+      assert_equal "USR2",        kill_call.args[0]
+      assert_equal ::Process.pid, kill_call.args[1]
+    end
+
+  end
+
+  class SendingASignalThatCantReadPIDTests < SendingASignalTests
+    desc "sending a signal when it can't read the PID file"
+    setup do
+      File.stubs(:read).raises("cant open file")
+    end
+    teardown do
+      File.unstub(:read)
+    end
+
+    should "raise an error about not being able to read the PID" do
+      exception = nil
+      begin; @process.call('stop'); rescue Exception => exception; end
+      assert_instance_of Qs::Process::InvalidError, exception
+      expected = "A PID couldn't be read from #{@daemon.pid_file.to_s.inspect}"
+      assert_equal expected, exception.message
+    end
+
+  end
+
+end


### PR DESCRIPTION
This adds a `Process` class that contains all the logic for
managing a daemon process. This includes, starting, stopping
and hot-restarting the process as needed. The process can run the
daemon and properly daemonize the process so it can run as a
service. It also handles trapping all the signals so the daemon
can be properly stopped and restarted as needed. This will allow
running a daemon process through the CLI and also stopping and
restarting it through the CLI.

This includes some `Daemon` logic, but this is all temporary. The
`Process` manages the daemon, so it has to interact with the daemon
to implement it's logic. This logic will change as the `Daemon`
is implemented.
