### PR TITLE
Make `Qs::Daemon` a mixin, not a class

### DIFF
--- a/lib/qs/daemon.rb
+++ b/lib/qs/daemon.rb
@@ -1,92 +1,89 @@
-module Qs
+module Qs; end
+module Qs::Daemon
 
-  class Daemon
+  # This is all temporary
+  attr_accessor :queue_name, :logger, :pid_file, :redis_ip, :redis_port
+  attr_accessor :thread, :state
 
-    # This is all temporary
-    attr_accessor :queue_name, :logger, :pid_file, :redis_ip, :redis_port
-    attr_accessor :thread, :state
+  def initialize
+    set_state :init
+    @signal_queue ||= []
+  end
 
-    def initialize
-      set_state :init
-      @signal_queue ||= []
-    end
-
-    def run
-      set_state :run
-      @thread = Thread.new do
-        loop do
-          break if !@state.run?
-          sleep 0.5
-          handle_signal(@signal_queue.pop) unless @signal_queue.empty?
-        end
+  def run
+    set_state :run
+    @thread = Thread.new do
+      loop do
+        break if !@state.run?
+        sleep 0.5
+        handle_signal(@signal_queue.pop) unless @signal_queue.empty?
       end
     end
+  end
 
-    def join_thread
-      @thread.join
+  def join_thread
+    @thread.join
+  end
+
+  def signal_stop
+    @signal_queue << :stop
+  end
+
+  def signal_halt
+    @signal_queue << :halt
+  end
+
+  def signal_restart
+    @signal_queue << :restart
+  end
+
+  def running?
+    @thread && @thread.alive?
+  end
+
+  def in_stop_state?
+    @state.stop?
+  end
+
+  def in_halt_state?
+    @state.halt?
+  end
+
+  def in_restart_state?
+    @state.restart?
+  end
+
+  private
+
+  def handle_signal(signal)
+    set_state(signal)
+  end
+
+  def set_state(name)
+    @state = State.new(name)
+  end
+
+  class State
+    def initialize(name)
+      @name = name.to_sym
+      # TODO - validation
     end
 
-    def signal_stop
-      @signal_queue << :stop
+    def run?
+      @name == :run
     end
 
-    def signal_halt
-      @signal_queue << :halt
+    def restart?
+      @name == :restart
     end
 
-    def signal_restart
-      @signal_queue << :restart
+    def stop?
+      @name == :stop
     end
 
-    def running?
-      @thread && @thread.alive?
+    def halt?
+      @name == :halt
     end
-
-    def in_stop_state?
-      @state.stop?
-    end
-
-    def in_halt_state?
-      @state.halt?
-    end
-
-    def in_restart_state?
-      @state.restart?
-    end
-
-    private
-
-    def handle_signal(signal)
-      set_state(signal)
-    end
-
-    def set_state(name)
-      @state = State.new(name)
-    end
-
-    class State
-      def initialize(name)
-        @name = name.to_sym
-        # TODO - validation
-      end
-
-      def run?
-        @name == :run
-      end
-
-      def restart?
-        @name == :restart
-      end
-
-      def stop?
-        @name == :stop
-      end
-
-      def halt?
-        @name == :halt
-      end
-    end
-
   end
 
 end

--- a/test/support/config_files/valid.qs
+++ b/test/support/config_files/valid.qs
@@ -1,3 +1,7 @@
 require 'qs'
 
-run Qs::Daemon.new # MyQueue
+class MyDaemon
+  include Qs::Daemon
+end
+
+run MyDaemon.new

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -5,7 +5,7 @@ require 'qs/daemon'
 
 class Qs::Config
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Qs::Config"
     setup do
       @file_path = SUPPORT_PATH.join('config_files/valid.qs')
@@ -17,13 +17,15 @@ class Qs::Config
     should have_cmeths :parse
 
     should "set the daemon with #run" do
-      my_daemon = Qs::Daemon.new
+      my_daemon_class = Class.new{ include Qs::Daemon }
+      my_daemon = my_daemon_class.new
       subject.run my_daemon
       assert_equal my_daemon, subject.daemon
     end
 
     should "return the daemon set with `run` using #daemon" do
-      assert_instance_of Qs::Daemon, subject.daemon
+      # `MyDaemon` is defined in `valid.qs`
+      assert_instance_of MyDaemon, subject.daemon
     end
 
     should "build a new config file and return it with #parse" do
@@ -33,7 +35,7 @@ class Qs::Config
 
   end
 
-  class WithoutQsTests < BaseTests
+  class WithoutQsTests < UnitTests
     desc "with a path string that doesn't end in .qs, but the file does"
     setup do
       @file_path = SUPPORT_PATH.join('config_files/valid')
@@ -42,12 +44,13 @@ class Qs::Config
     should "find the file and parse it" do
       config = nil
       assert_nothing_raised{ config = Qs::Config.new(@file_path) }
-      assert_instance_of Qs::Daemon, config.daemon
+      # `MyDaemon` is defined in `valid.qs`
+      assert_instance_of MyDaemon, subject.daemon
     end
 
   end
 
-  class NoFileTests < BaseTests
+  class NoFileTests < UnitTests
     desc "with a path string for a file that doesn't exist"
     setup do
       @file_path = SUPPORT_PATH.join('dont_exist')
@@ -75,7 +78,7 @@ class Qs::Config
 
   end
 
-  class NoRunTests < BaseTests
+  class NoRunTests < UnitTests
     desc "with a config file that doesn't call `run`"
     setup do
       @file_path = SUPPORT_PATH.join('config_files/empty.qs')
@@ -93,7 +96,7 @@ class Qs::Config
 
   end
 
-  class InvalidDaemonTests < BaseTests
+  class InvalidDaemonTests < UnitTests
     desc "with a config file that calls `run` but not with a Qs::Daemon"
     setup do
       @file_path = SUPPORT_PATH.join('config_files/invalid.qs')

--- a/test/unit/process_tests.rb
+++ b/test/unit/process_tests.rb
@@ -11,7 +11,7 @@ class Qs::Process
   class UnitTests < Assert::Context
     desc "Qs::Process"
     setup do
-      @daemon = Qs::Daemon.new
+      @daemon = ProcessTestsDaemon.new
       @daemon.queue_name = "test__main"
       @daemon.logger     = Logger.new(File.open(ROOT.join("log/test.log"), 'w'))
       @daemon.pid_file   = ROOT.join("tmp/test.pid")
@@ -262,6 +262,10 @@ class Qs::Process
       assert_equal expected, exception.message
     end
 
+  end
+
+  class ProcessTestsDaemon
+    include Qs::Daemon
   end
 
 end


### PR DESCRIPTION
This is a small change to make the `Qs::Daemon` more like the
`Deas::Server`, a mixin that is used to define a daemon. This will
be changed more to work like the `Deas::Server` but this change
revealed an issue with the file evaluation. This switches our
file evaluation to use Rack's trick of evaluating the file's
contents into a proc and then instance evaluating that. This
produces more expected behavior. The previous implementation had
the side effect of defining constants namespaced to the instance
of the `Config` that evaluated them. This was very confusing in
the tests and could have other issues, so I decided to switch it
to the less-simple implemenation from Rack. I believe this will
produce more expected results and not cause any strange errors
down the road.
