### PR TITLE
Add daemon configuration, provides options and validation

### DIFF
--- a/lib/qs/daemon.rb
+++ b/lib/qs/daemon.rb
@@ -1,68 +1,173 @@
+require 'ns-options'
+require 'ns-options/boolean'
+
+require 'qs/queue'
+
 module Qs; end
 module Qs::Daemon
 
-  # This is all temporary
-  attr_accessor :queue_name, :logger, :pid_file, :redis_ip, :redis_port
-  attr_accessor :thread, :state
+  class Configuration
+    include NsOptions::Proxy
 
-  def initialize
-    set_state :init
-    @signal_queue ||= []
+    option :pid_file, String, :default => 'qs.pid'
+
+    option :min_workers, Integer, :default => 4
+    option :max_workers, Integer, :default => 4
+
+    option :wait_timeout,     Integer, :default => 5
+    option :shutdown_timeout, Integer, :default => nil
+
+    attr_accessor :error_procs, :init_procs, :queue
+
+    def initialize(values = nil)
+      self.apply(values || {})
+      @error_procs, @init_procs = [], []
+      @queue = Qs::Queue.new
+      @valid = nil
+    end
+
+    def valid?
+      !!@valid
+    end
+
+    # for the config to be considered "valid", a few things need to happen.  The
+    # key here is that this only needs to be done _once_ for each config.
+
+    def validate!
+      return @valid if !@valid.nil?  # only need to run this once per config
+
+      # ensure all user and plugin configs/settings are applied
+      self.init_procs.each{ |p| p.call }
+
+      # validate the jobs / event mappings
+      self.mappings.each(&:validate!)
+
+      @valid = true  # if it made it this far, its valid!
+    end
+
+    def mappings
+      self.queue.mappings
+    end
+
   end
 
-  def run
-    set_state :run
-    @thread = Thread.new do
-      loop do
-        break if !@state.run?
-        sleep 0.5
-        handle_signal(@signal_queue.pop) unless @signal_queue.empty?
-      end
+  def self.included(klass)
+    klass.class_eval do
+      extend ClassMethods
+      include InstanceMethods
     end
   end
 
-  def join_thread
-    @thread.join
+  module ClassMethods
+
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+    def pid_file(*args)
+      self.configuration.pid_file(*args)
+    end
+
+    def min_workers(*args)
+      self.configuration.min_workers(*args)
+    end
+
+    def max_workers(*args)
+      self.configuration.max_workers(*args)
+    end
+
+    def workers(*args)
+      self.min_workers(*args)
+      self.max_workers(*args)
+    end
+
+    def wait_timeout(*args)
+      self.configuration.wait_timeout(*args)
+    end
+
+    def shutdown_timeout(*args)
+      self.configuration.shutdown_timeout(*args)
+    end
+
   end
 
-  def signal_stop
-    @signal_queue << :stop
+  module InstanceMethods
+
+    attr_reader :configuration
+
+    def initialize
+      @configuration = Configuration.new(self.class.configuration.to_hash)
+      @configuration.validate!
+
+      # TODO - state and signal handling
+      set_state :init
+      @signal_queue ||= []
+    end
+
+    def pid_file
+      @configuration.pid_file
+    end
+
+    # This is all temporary
+    attr_accessor :queue_name, :logger, :redis_ip, :redis_port
+    attr_accessor :thread, :state
+
+    def run
+      set_state :run
+      @thread = Thread.new do
+        loop do
+          break if !@state.run?
+          sleep 0.5
+          handle_signal(@signal_queue.pop) unless @signal_queue.empty?
+        end
+      end
+    end
+
+    def join_thread
+      @thread.join
+    end
+
+    def signal_stop
+      @signal_queue << :stop
+    end
+
+    def signal_halt
+      @signal_queue << :halt
+    end
+
+    def signal_restart
+      @signal_queue << :restart
+    end
+
+    def running?
+      @thread && @thread.alive?
+    end
+
+    def in_stop_state?
+      @state.stop?
+    end
+
+    def in_halt_state?
+      @state.halt?
+    end
+
+    def in_restart_state?
+      @state.restart?
+    end
+
+    private
+
+    def handle_signal(signal)
+      set_state(signal)
+    end
+
+    def set_state(name)
+      @state = State.new(name)
+    end
+
   end
 
-  def signal_halt
-    @signal_queue << :halt
-  end
-
-  def signal_restart
-    @signal_queue << :restart
-  end
-
-  def running?
-    @thread && @thread.alive?
-  end
-
-  def in_stop_state?
-    @state.stop?
-  end
-
-  def in_halt_state?
-    @state.halt?
-  end
-
-  def in_restart_state?
-    @state.restart?
-  end
-
-  private
-
-  def handle_signal(signal)
-    set_state(signal)
-  end
-
-  def set_state(name)
-    @state = State.new(name)
-  end
-
+  # TODO - not sure what I want to do with the state handling yet
   class State
     def initialize(name)
       @name = name.to_sym

--- a/lib/qs/queue.rb
+++ b/lib/qs/queue.rb
@@ -1,0 +1,11 @@
+module Qs; end
+class Qs::Queue
+
+  # This is temporary, just defining what a daemon needs from a queue
+  attr_accessor :mappings
+
+  def initialize
+    @mappings = []
+  end
+
+end

--- a/qs.gemspec
+++ b/qs.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
+  gem.add_dependency("ns-options", ["~> 1.1", ">= 1.1.4"])
+
   gem.add_development_dependency("assert")
   gem.add_development_dependency("assert-mocha")
 

--- a/test/unit/daemon_configuration_tests.rb
+++ b/test/unit/daemon_configuration_tests.rb
@@ -1,0 +1,94 @@
+require 'assert'
+require 'qs/daemon'
+
+class Qs::Daemon::Configuration
+
+  class UnitTests < Assert::Context
+    desc "Qs::Daemon::Configuration"
+    setup do
+      @configuration = Qs::Daemon::Configuration.new
+    end
+    subject{ @configuration }
+
+    should have_imeths :pid_file
+    should have_imeths :min_workers, :max_workers
+    should have_imeths :wait_timeout, :shutdown_timeout
+
+    should have_accessors :init_procs, :error_procs, :queue
+
+    should have_imeths :valid?, :validate!, :mappings
+
+    should "apply a hash's values when initialized" do
+      configuration = Qs::Daemon::Configuration.new :pid_file => 'test.pid'
+      assert_equal 'test.pid', configuration.pid_file
+    end
+
+    should "build a new Queue when initialized" do
+      assert_instance_of Qs::Queue, subject.queue
+    end
+
+    should "default it's pid file" do
+      assert_equal 'qs.pid', subject.pid_file
+    end
+
+    should "default it's min and max workers" do
+      assert_equal 4, subject.min_workers
+      assert_equal 4, subject.max_workers
+    end
+
+    should "default it's wait and shutdown timeout" do
+      assert_equal 5,   subject.wait_timeout
+      assert_equal nil, subject.shutdown_timeout
+    end
+
+    should "default it's init and error procs" do
+      assert_equal [], subject.init_procs
+      assert_equal [], subject.error_procs
+    end
+
+    should "not be valid until it's validated" do
+      assert_equal false, subject.valid?
+      subject.validate!
+      assert_equal true, subject.valid?
+    end
+
+    should "return it's queue's mappings with #mappings" do
+      subject.queue.mappings = [ mock('Mapping') ]
+      assert_equal subject.queue.mappings, subject.mappings
+    end
+
+  end
+
+  class ValidateTests < UnitTests
+    desc "when validated"
+    setup do
+      @queue = Qs::Queue.new
+      @configuration.queue = @queue
+    end
+
+    should "call it's init procs" do
+      init_proc_called = false
+      @configuration.init_procs << proc{ init_proc_called = true }
+      assert_nothing_raised{ subject.validate! }
+      assert_equal true, init_proc_called
+    end
+
+    should "call `validate!` on any mappings" do
+      # TODO - switch out mock / stub with actual behavior or at least behavior
+      # more true to the implementation
+      @queue.mappings = [
+        mock('Mapping').tap{ |m| m.stubs(:validate!).raises(StandardError) }
+      ]
+      assert_raises(StandardError){ subject.validate! }
+    end
+
+    should "only be done once" do
+      assert_nothing_raised{ subject.validate! }
+      assert_equal true, subject.valid?
+      @configuration.init_procs << proc{ raise("shouldn't be called") }
+      assert_nothing_raised{ subject.validate! }
+    end
+
+  end
+
+end

--- a/test/unit/daemon_tests.rb
+++ b/test/unit/daemon_tests.rb
@@ -1,0 +1,91 @@
+require 'assert'
+require 'qs/daemon'
+
+module Qs::Daemon
+
+  class UnitTests < Assert::Context
+    desc "Qs::Daemon"
+    setup do
+      @daemon_class = Class.new{ include Qs::Daemon }
+      @daemon = @daemon_class.new
+    end
+    subject{ @daemon }
+
+    should have_cmeths :configuration
+    should have_cmeths :pid_file
+    should have_cmeths :min_workers, :max_workers, :workers
+    should have_cmeths :wait_timeout, :shutdown_timeout
+
+    should have_imeths :pid_file
+
+    should "build it's configuration from it's class's configuration" do
+      @daemon_class.configuration.pid_file = 'test.pid'
+      daemon = @daemon_class.new
+      assert_equal 'test.pid', daemon.configuration.pid_file
+    end
+
+    should "return it's configuration's pid file with #pid_file" do
+      assert_equal subject.configuration.pid_file, subject.pid_file
+    end
+
+  end
+
+  class ValidateConfigurationTests < UnitTests
+    desc "with an invalid config"
+    setup do
+      config = mock('Qs::Daemon::Configuration')
+      Configuration.stubs(:new).returns(config)
+      config.stubs(:validate!).raises(StandardError)
+    end
+    teardown do
+      Configuration.unstub(:new)
+    end
+
+    should "validate the configuration when initialized" do
+      assert_raises(StandardError){ @daemon_class.new }
+    end
+
+  end
+
+  class ClassMethodTests < UnitTests
+    desc "class"
+    subject{ @daemon_class }
+
+    should "return an instance of a Configuration with #configuration" do
+      assert_instance_of Configuration, subject.configuration
+    end
+
+    should "allow reading/writing the configuration's pid file" do
+      assert_nothing_raised{ subject.pid_file 'test.pid' }
+      assert_equal 'test.pid', subject.pid_file
+    end
+
+    should "allow reading/writing the configuration's min workers" do
+      assert_nothing_raised{ subject.min_workers 2 }
+      assert_equal 2, subject.min_workers
+    end
+
+    should "allow reading/writing the configuration's max workers" do
+      assert_nothing_raised{ subject.max_workers 2 }
+      assert_equal 2, subject.max_workers
+    end
+
+    should "allow setting both it's min and max workers with #workers" do
+      assert_nothing_raised{ subject.workers 3 }
+      assert_equal 3, subject.min_workers
+      assert_equal 3, subject.max_workers
+    end
+
+    should "allow reading/writing the configuration's wait timeout" do
+      assert_nothing_raised{ subject.wait_timeout 1 }
+      assert_equal 1, subject.wait_timeout
+    end
+
+    should "allow reading/writing the configuration's shutdown timeout" do
+      assert_nothing_raised{ subject.shutdown_timeout 15 }
+      assert_equal 15, subject.shutdown_timeout
+    end
+
+  end
+
+end

--- a/test/unit/process_tests.rb
+++ b/test/unit/process_tests.rb
@@ -14,7 +14,6 @@ class Qs::Process
       @daemon = ProcessTestsDaemon.new
       @daemon.queue_name = "test__main"
       @daemon.logger     = Logger.new(File.open(ROOT.join("log/test.log"), 'w'))
-      @daemon.pid_file   = ROOT.join("tmp/test.pid")
       @daemon.redis_ip   = "0.0.0.0"
       @daemon.redis_port = 1234
       @process = Qs::Process.new(@daemon)
@@ -266,6 +265,8 @@ class Qs::Process
 
   class ProcessTestsDaemon
     include Qs::Daemon
+
+    pid_file ROOT.join("tmp/test.pid")
   end
 
 end


### PR DESCRIPTION
This follows the Deas pattern for a server's configuration and
add's a configuration class for a `Daemon`. This provides the
daemon options and will validate the configuration. This will
allow user's to customize a daemon and also ensure that their
configuration and queue will run as expected. This provides a
friendlier experience than it erroring later after the process
has already started and tries to run a job.
