### PR TITLE
Update daemon config and `Process` interaction

### DIFF
--- a/lib/qs/process.rb
+++ b/lib/qs/process.rb
@@ -38,7 +38,7 @@ module Qs
         @daemon       = daemon
         @queue_name   = @daemon.queue_name
         @logger       = @daemon.logger
-        @process_name = ProcessName.new(@daemon)
+        @process_name = ProcessName.new(@queue_name)
         @pid_file     = PIDFile.new(@daemon.pid_file)
         @restart_cmd  = RestartCmd.new
       end
@@ -147,8 +147,8 @@ module Qs
     end
 
     class ProcessName < String
-      def initialize(daemon)
-        super "qs_#{daemon.queue_name}_#{daemon.redis_ip}_#{daemon.redis_port}"
+      def initialize(queue_name)
+        super "qs_#{queue_name}"
       end
     end
 

--- a/lib/qs/queue.rb
+++ b/lib/qs/queue.rb
@@ -2,7 +2,7 @@ module Qs; end
 class Qs::Queue
 
   # This is temporary, just defining what a daemon needs from a queue
-  attr_accessor :mappings
+  attr_accessor :name, :logger, :mappings
 
   def initialize
     @mappings = []


### PR DESCRIPTION
This cleans up and formalizes some of the `Daemon` interface,
specifically where it interacts with the `Process`. This was
originally hacked in to make the `Process` work as needed. The
options that the `Process` class uses are now set using the DSL
and others are properly pulled from the `Queue`. This revealed
that the `queue`, `init_procs` and `error_procs` for a daemon's
configuration were not being copied down from the class to the
instance correctly. This sets up updates to the signal handling,
which affects the `Process` class.
