### PR TITLE
Update `Daemon` state and `Process` signal handling

### DIFF
--- a/lib/qs/queue.rb
+++ b/lib/qs/queue.rb
@@ -1,3 +1,5 @@
+require 'logger'
+
 module Qs; end
 class Qs::Queue
 
@@ -5,6 +7,7 @@ class Qs::Queue
   attr_accessor :name, :logger, :mappings
 
   def initialize
+    @logger ||= Logger.new(File.open("/dev/null", 'w'))
     @mappings = []
   end
 

--- a/test/unit/daemon_tests.rb
+++ b/test/unit/daemon_tests.rb
@@ -1,6 +1,8 @@
 require 'assert'
 require 'qs/daemon'
 
+require 'thread'
+
 module Qs::Daemon
 
   class UnitTests < Assert::Context
@@ -19,6 +21,10 @@ module Qs::Daemon
     should have_cmeths :wait_timeout, :shutdown_timeout
 
     should have_readers :queue_name, :pid_file, :logger
+    should have_writers :check_for_signals_proc
+
+    should have_imeths :start, :stop, :halt
+    should have_imeths :running?, :stopped?, :halted?
 
     should "return it's configuration's pid file with #pid_file" do
       assert_equal @daemon_class.configuration.pid_file, subject.pid_file
@@ -30,6 +36,101 @@ module Qs::Daemon
 
     should "return it's queue's logger with #logger" do
       assert_equal @queue.logger, subject.logger
+    end
+
+    should "be stopped by default" do
+      assert subject.stopped?
+      assert_not subject.running?
+      assert_not subject.halted?
+    end
+
+  end
+
+  class StartTests < UnitTests
+    desc "when started"
+    setup do
+      @check_for_signals_proc_called = 0
+      @daemon.check_for_signals_proc = proc{ @check_for_signals_proc_called += 1 }
+      @thread = @daemon.start
+    end
+    teardown do
+      @daemon.stop
+    end
+
+    should "set the daemon's state to running" do
+      assert subject.running?
+      assert_not subject.stopped?
+      assert_not subject.halted?
+    end
+
+    should "return a the daemon's work loop thread" do
+      assert_instance_of Thread, @thread
+      assert @thread.alive?
+    end
+
+    should "call `check_for_signals_proc` as part of it's work loop" do
+      @thread.join(0.1)
+      assert @check_for_signals_proc_called > 0
+    end
+
+  end
+
+  class StopTests < UnitTests
+    desc "when stopped"
+    setup do
+      @thread = @daemon.start
+      @daemon.stop
+    end
+
+    should "set the daemon's state to stopped" do
+      assert subject.stopped?
+      assert_not subject.running?
+      assert_not subject.halted?
+    end
+
+    should "stop the daemon's work loop thread" do
+      assert_not_nil @thread.join(5)
+      assert_not @thread.alive?
+    end
+
+  end
+
+  class HaltTests < UnitTests
+    desc "when halted"
+    setup do
+      @thread = @daemon.start
+      @daemon.halt
+    end
+
+    should "set the daemon's state to halted" do
+      assert subject.halted?
+      assert_not subject.running?
+      assert_not subject.stopped?
+    end
+
+    should "stop the daemon's work loop thread" do
+      assert_not_nil @thread.join(5)
+      assert_not @thread.alive?
+    end
+
+  end
+
+  class WaitingForShutdownTests < UnitTests
+    setup do
+      @thread = @daemon.start
+    end
+    teardown do
+      @daemon.stop
+    end
+
+    should "allow waiting for the daemon to shutdown using #stop" do
+      subject.stop(true)
+      assert_not @thread.alive?
+    end
+
+    should "allow waiting for the daemon to shutdown using #halt" do
+      subject.halt(true)
+      assert_not @thread.alive?
     end
 
   end

--- a/test/unit/process_tests.rb
+++ b/test/unit/process_tests.rb
@@ -70,7 +70,7 @@ class Qs::Process
 
     def shutdown_thread
       if @process_thread && @process_thread.alive?
-        @daemon.signal_stop
+        @daemon.stop
         @process_thread.join
       end
     end
@@ -95,7 +95,7 @@ class Qs::Process
     end
 
     should "remove the PID file when it exits" do
-      @daemon.signal_stop
+      @daemon.stop
       @process_thread.join
       assert_not File.exists?(@daemon.pid_file)
     end
@@ -117,7 +117,7 @@ class Qs::Process
 
       trap_call.block.call
       @process_thread.join
-      assert @daemon.in_stop_state?
+      assert @daemon.stopped?
       assert_not @daemon.running?
     end
 
@@ -127,7 +127,7 @@ class Qs::Process
 
       trap_call.block.call
       @process_thread.join
-      assert @daemon.in_halt_state?
+      assert @daemon.halted?
       assert_not @daemon.running?
     end
 
@@ -137,7 +137,7 @@ class Qs::Process
 
       trap_call.block.call
       @process_thread.join
-      assert @daemon.in_restart_state?
+      assert @daemon.stopped?
       assert_not @daemon.running?
 
       # should have restarted the current process


### PR DESCRIPTION
This updates and formalizes the `Daemon`'s state handling and the
`Process` signal handling. This moves the signal handling logic
more fully into the `Process` and has it drive the `Daemon`'s
state as needed. A `Daemon` now provies a proc callback that's
part of the work loop. The callback is intended as a chance to
check for signals. This moves signal handling fully into the
`Process` and allowed simplifying the `Daemon`'s interface. A
`Daemon` no longer is aware of a "restart" state. This was a
state that was no different (and never would be different) from the
stop state. It served only as a trigger for the `Process` to run
an `exec` command. Since the `Process` is the only one that cared
about it, it shouldn't be in the `Daemon`.

This sets up using `DatWorkerPool` in a `Daemon` and having a
proper work loop that checks for work and adds it to the pool as
its available.
