### PR TITLE
Add `Daemon` work loop that uses `DatWorkerPool`

### DIFF
--- a/lib/qs/queue.rb
+++ b/lib/qs/queue.rb
@@ -11,4 +11,9 @@ class Qs::Queue
     @mappings = []
   end
 
+  def fetch_job(timeout = nil)
+    sleep(timeout) if timeout
+    'test'
+  end
+
 end

--- a/lib/qs/worker.rb
+++ b/lib/qs/worker.rb
@@ -1,0 +1,12 @@
+module Qs
+
+  class Worker
+
+    def initialize(queue, error_procs = nil)
+      # TODO
+      raise NotImplementedError
+    end
+
+  end
+
+end

--- a/qs.gemspec
+++ b/qs.gemspec
@@ -18,7 +18,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency("ns-options", ["~> 1.1", ">= 1.1.4"])
+  gem.add_dependency("dat-worker-pool", ["~> 0.2"])
+  gem.add_dependency("ns-options",      ["~> 1.1", ">= 1.1.4"])
 
   gem.add_development_dependency("assert")
   gem.add_development_dependency("assert-mocha")

--- a/test/unit/process_tests.rb
+++ b/test/unit/process_tests.rb
@@ -69,10 +69,9 @@ class Qs::Process
     end
 
     def shutdown_thread
-      if @process_thread && @process_thread.alive?
-        @daemon.stop
-        @process_thread.join
-      end
+      @daemon.stop(true)
+      @process_thread.join if @process_thread
+      @process_thread = nil
     end
 
   end
@@ -95,7 +94,7 @@ class Qs::Process
     end
 
     should "remove the PID file when it exits" do
-      @daemon.stop
+      @daemon.stop(true)
       @process_thread.join
       assert_not File.exists?(@daemon.pid_file)
     end
@@ -273,7 +272,7 @@ class Qs::Process
     queue ProcessTestsQueue
     pid_file ROOT.join("tmp/test.pid")
     workers 1
-    wait_timeout 0.1
+    wait_timeout 0.5
   end
 
 end


### PR DESCRIPTION
This adds the logic to the work loop to use a worker pool. The
`Daemon` will build a worker pool using it's configuration and add
work to it from the queue. Work is only added when there is a
worker available and the pool doesn't already have work. This will
minimize the main work loop thread from pulling all jobs out of
redis and into the in-memory queue. This sets up pulling jobs from
the queue using redis and actually running a job with a configured
handler using a `Qs::Daemon::Worker`.

We don't want jobs pulled out of Redis and into the memory because
we never know when the process will be stopped or restarted. When
this happens, any jobs in-memory have to either be run or they will
be lost. Eventually, the shutdown logic for the daemon will run any
remaining jobs before shutting down.

@kellyredding - This is still needs to have a version of `DatWorkerPool` rolled before I'm ready to merge it.
