### PR TITLE
Add `Worker` class; parses job, finds handler and runs it

### DIFF
--- a/lib/qs/daemon.rb
+++ b/lib/qs/daemon.rb
@@ -164,8 +164,8 @@ module Qs::Daemon
 
     def work_loop
       @logger.debug "Starting work loop..."
-      @worker_pool = DatWorkerPool.new(@min_workers, @max_workers) do |job|
-        process(job)
+      @worker_pool = DatWorkerPool.new(@min_workers, @max_workers) do |encoded_job|
+        process(encoded_job)
       end
       while started?
         check_for_signals

--- a/lib/qs/error_handler.rb
+++ b/lib/qs/error_handler.rb
@@ -1,0 +1,17 @@
+module Qs
+
+  class ErrorHandler
+
+    def initialize(error_procs, queue)
+      @error_procs = [*error_procs].compact
+      @queue       = queue
+    end
+
+    def run(exception, job = nil)
+      # TODO
+      raise NotImplementedError
+    end
+
+  end
+
+end

--- a/lib/qs/job.rb
+++ b/lib/qs/job.rb
@@ -1,0 +1,20 @@
+module Qs
+
+  class Job
+
+    def self.parse(job_string)
+      self.new({}) # TODO
+    end
+
+    attr_reader :name, :type, :params
+
+    def initialize(job_hash)
+      # TODO
+      @name   = 'test_job'
+      @type   = 'job'
+      @params = { 'some' => 'param' }
+    end
+
+  end
+
+end

--- a/lib/qs/runner.rb
+++ b/lib/qs/runner.rb
@@ -1,0 +1,18 @@
+module Qs
+
+  class Runner
+
+    def self.run(handler_class, job, logger)
+      self.new(handler_class, job, logger).run
+    end
+
+    def initialize(handler_class, job, logger = nil)
+      # TODO
+      @handler_class = handler_class
+      @job           = job
+      @logger        = logger
+    end
+
+  end
+
+end

--- a/lib/qs/worker.rb
+++ b/lib/qs/worker.rb
@@ -1,10 +1,83 @@
+require 'benchmark'
+
+require 'qs/error_handler'
+require 'qs/job'
+require 'qs/runner'
+
 module Qs
 
   class Worker
 
     def initialize(queue, error_procs = nil)
-      # TODO
-      raise NotImplementedError
+      @queue  = queue
+      @logger = @queue.logger
+      @error_handler = Qs::ErrorHandler.new(error_procs, @queue)
+    end
+
+    def run(encoded_job)
+      log_received
+      benchmark  = Benchmark.measure{ run!(encoded_job) }
+      time_taken = RoundedTime.new(benchmark.real)
+      log_complete(time_taken)
+    end
+
+    private
+
+    def run!(encoded_job)
+      job = Qs::Job.parse(encoded_job)
+      log_job(job)
+
+      handler_class = @queue.handler_class_for(job.type, job.name)
+      log_handler_class(handler_class)
+
+      Qs::Runner.new(handler_class, job, @logger).run
+    rescue Exception => exception
+      handle_exception(exception, job)
+    end
+
+    def handle_exception(exception, job)
+      exception = @error_handler.run(exception, job)
+      log_exception(exception)
+      raise_if_debugging!(exception)
+    end
+
+    def raise_if_debugging!(exception)
+      raise exception if exception && ENV['QS_DEBUG']
+    end
+
+    def log_received
+      log "===== Received job ====="
+    end
+
+    def log_job(job)
+      log "  Type:    #{job.type.inspect}"
+      log "  Name:    #{job.name.inspect}"
+      log "  Params:  #{job.params.inspect}"
+    end
+
+    def log_handler_class(handler_class)
+      log "  Handler: #{handler_class}"
+    end
+
+    def log_complete(time_taken)
+      log "===== Completed in #{time_taken}s ====="
+    end
+
+    def log_exception(exception)
+      log("#{exception.class}: #{exception.message}", :error)
+      log(exception.backtrace.join("\n"), :error)
+    end
+
+    def log(message, level = :info)
+      @logger.send(level, "[Qs] #{message}")
+    end
+
+    module RoundedTime
+      ROUND_PRECISION = 2
+      ROUND_MODIFIER  = 10 ** ROUND_PRECISION
+      def self.new(time_in_seconds)
+        (time_in_seconds * ROUND_MODIFIER).to_i / ROUND_MODIFIER.to_f
+      end
     end
 
   end

--- a/test/unit/worker_tests.rb
+++ b/test/unit/worker_tests.rb
@@ -1,0 +1,142 @@
+require 'assert'
+require 'qs/worker'
+
+require 'qs/queue'
+
+class Qs::Worker
+
+  class UnitTests < Assert::Context
+    desc "Qs::Worker"
+    setup do
+      @spy_logger   = SpyLogger.new
+      @queue        = Qs::Queue.new
+      @queue.logger = @spy_logger
+      @error_procs  = [ proc{ } ]
+      @worker = Qs::Worker.new(@queue, @error_procs)
+    end
+    subject{ @worker }
+
+    should have_imeths :run
+
+  end
+
+  class RunTests < UnitTests
+    setup do
+      @encoded_job   = 'some job'
+      @job           = Qs::Job.new({})
+      @handler_class = Class.new
+      @spy_runner    = SpyRunner.new
+
+      Qs::Job.stubs(:parse).tap do |s|
+        s.with(@encoded_job)
+        s.returns(@job)
+      end
+      @queue.stubs(:handler_class_for).tap do |s|
+        s.with(@job.type, @job.name)
+        s.returns(@handler_class)
+      end
+      Qs::Runner.stubs(:new).tap do |s|
+        s.with(@handler_class, @job, @queue.logger)
+        s.returns(@spy_runner)
+      end
+    end
+    teardown do
+      Qs::Runner.unstub(:new)
+      Qs::Job.unstub(:parse)
+    end
+  end
+
+  class RunThatSucceedsTests < RunTests
+    desc "run that succeeds"
+    setup do
+      @worker.run(@encoded_job)
+    end
+
+    should "parse the job, find a handler class and run it" do
+      assert @spy_runner.run_called
+    end
+
+    should "log the process of running the job" do
+      expected = [
+        "[Qs] ===== Received job =====",
+        "[Qs]   Type:    #{@job.type.inspect}",
+        "[Qs]   Name:    #{@job.name.inspect}",
+        "[Qs]   Params:  #{@job.params.inspect}",
+        "[Qs]   Handler: #{@handler_class.inspect}",
+        "[Qs] ===== Completed in 0.0s ====="
+      ]
+      assert_equal expected, @spy_logger.info_messages
+    end
+
+  end
+
+  class RunThatFailsTests < RunTests
+    desc "run that fails"
+    setup do
+      @exception = RuntimeError.new('test')
+      @spy_error_handler = SpyErrorHandler.new
+
+      @spy_runner.stubs(:run).raises(@exception)
+      Qs::ErrorHandler.stubs(:new).tap do |s|
+        s.with(@error_procs, @queue)
+        s.returns(@spy_error_handler)
+      end
+
+      @worker = Qs::Worker.new(@queue, @error_procs)
+      @worker.run(@encoded_job)
+    end
+
+    should "have run the error handler with the exception and job" do
+      error_handled = @spy_error_handler.errors_handled.last
+      assert_equal @exception, error_handled.exception
+      assert_equal @job,       error_handled.job
+    end
+
+    should "log the exception" do
+      expected = [
+        "[Qs] #{@exception.class}: #{@exception.message}",
+        "[Qs] #{@exception.backtrace.join("\n")}"
+      ]
+      assert_equal expected, @spy_logger.error_messages
+    end
+
+  end
+
+  class SpyLogger
+    attr_reader :info_messages, :error_messages
+    def initialize
+      @info_messages  = []
+      @error_messages = []
+    end
+    def info(message)
+      @info_messages  << message
+    end
+    def error(message)
+      @error_messages << message
+    end
+  end
+
+  class SpyRunner
+    attr_reader :run_called
+    def initialize
+      @run_called = false
+    end
+    def run
+      @run_called = true
+    end
+  end
+
+  class SpyErrorHandler
+    attr_reader :errors_handled
+    def initialize
+      @errors_handled = []
+    end
+    def run(exception, job)
+      @errors_handled << ErrorHandled.new(exception, job)
+      exception
+    end
+  end
+
+  ErrorHandled = Struct.new(:exception, :job)
+
+end


### PR DESCRIPTION
This adds a `Worker` class that handles parsing a job, finding a
handler class for it and running the handler. The worker is called
when a job is pulled off the queue. The worker is responsible for
properly logging the process of running the job and for handling
any errors that occur. This provides the next layer for processing
background jobs and events.
