### PR TITLE
Add `ErrorHandler`, calls a list of procs when running a job fails

### DIFF
--- a/lib/qs/error_handler.rb
+++ b/lib/qs/error_handler.rb
@@ -2,14 +2,23 @@ module Qs
 
   class ErrorHandler
 
-    def initialize(error_procs, queue)
+    def initialize(queue, error_procs)
       @error_procs = [*error_procs].compact
       @queue       = queue
     end
 
+    # If an error is raised from an error proc, it will be passed to the next
+    # error proc. This is designed to avoid "hidden" errors happening, this way
+    # the daemon will log based on the last exception that occurred.
     def run(exception, job = nil)
-      # TODO
-      raise NotImplementedError
+      @error_procs.each do |error_proc|
+        begin
+          error_proc.call(exception, @queue, job)
+        rescue Exception => proc_exception
+          exception = proc_exception
+        end
+      end
+      exception
     end
 
   end

--- a/lib/qs/worker.rb
+++ b/lib/qs/worker.rb
@@ -11,7 +11,7 @@ module Qs
     def initialize(queue, error_procs = nil)
       @queue  = queue
       @logger = @queue.logger
-      @error_handler = Qs::ErrorHandler.new(error_procs, @queue)
+      @error_handler = Qs::ErrorHandler.new(@queue, error_procs)
     end
 
     def run(encoded_job)

--- a/test/unit/error_handler_tests.rb
+++ b/test/unit/error_handler_tests.rb
@@ -1,0 +1,97 @@
+require 'assert'
+require 'qs/error_handler'
+
+require 'qs/queue'
+
+class Qs::ErrorHandler
+
+  class UnitTests < Assert::Context
+    desc "Qs::ErrorHandler"
+    setup do
+      @last_call = nil
+      error_proc = proc{ |e, q, j| @last_call = ProcCall.new(e, q, j) }
+      @queue = Qs::Queue.new
+      @error_handler = Qs::ErrorHandler.new(@queue, [ error_proc ])
+    end
+    subject{ @error_handler }
+
+    should have_imeths :run
+
+    should "return the exception that it 'handled'" do
+      exception = StandardError.new('test')
+      returned_exception = subject.run(exception)
+      assert_same exception, returned_exception
+    end
+
+    should "call the error proc passing the exception, queue and job" do
+      exception = StandardError.new('test')
+      job       = 'test'
+      subject.run(exception, job)
+      assert_not_nil @last_call
+      assert_equal exception, @last_call.exception
+      assert_equal @queue,    @last_call.queue
+      assert_equal job,       @last_call.job
+    end
+
+  end
+
+  class MultipleErrorProcTests < UnitTests
+    desc "with multiple error procs"
+    setup do
+      @calls = []
+      first_error_proc  = proc{ @calls << :first }
+      second_error_proc = proc{ @calls << :second }
+      @error_handler = Qs::ErrorHandler.new(@queue, [
+        first_error_proc,
+        second_error_proc
+      ])
+      @error_handler.run(StandardError.new)
+    end
+
+    should "call each error proc in order" do
+      assert_equal [ :first, :second ], @calls
+    end
+
+  end
+
+  class WithFailingErrorProcTests < UnitTests
+    desc "when an error proc generates an exception"
+    setup do
+      @proc_exception = StandardError.new('not expected')
+      first_error_proc  = proc{ raise(@proc_exception) }
+      second_error_proc = proc{ |e, q, j| @caught_exception = e }
+      @error_handler = Qs::ErrorHandler.new(@queue, [
+        first_error_proc,
+        second_error_proc
+      ])
+      @returned_exception = @error_handler.run(StandardError.new)
+    end
+
+    should "call the next error procs with the new exception" do
+      assert_same @proc_exception, @caught_exception
+    end
+
+    should "return the exception last occurred" do
+      assert_same @proc_exception, @returned_exception
+    end
+
+  end
+
+  class WhenLastErrorProcFailsTests < UnitTests
+    desc "when the last error proc generates an exception"
+    setup do
+      @proc_exception = StandardError.new('not expected')
+      error_proc = proc{ |e, q, j| raise(@proc_exception) }
+      @error_handler = Qs::ErrorHandler.new(@queue, [ error_proc ])
+      @returned_exception = @error_handler.run(StandardError.new)
+    end
+
+    should "return the new exception" do
+      assert_same @returned_exception, @proc_exception
+    end
+
+  end
+
+  ProcCall = Struct.new(:exception, :queue, :job)
+
+end

--- a/test/unit/worker_tests.rb
+++ b/test/unit/worker_tests.rb
@@ -78,7 +78,7 @@ class Qs::Worker
 
       @spy_runner.stubs(:run).raises(@exception)
       Qs::ErrorHandler.stubs(:new).tap do |s|
-        s.with(@error_procs, @queue)
+        s.with(@queue, @error_procs)
         s.returns(@spy_error_handler)
       end
 


### PR DESCRIPTION
This adds the `ErrorHandler` which is responsible for properly
calling any configured error procs, providing the exception,
queue and job. The error handler has to manage edge cases where
error procs fail as well. This ensures error procs are called
in a consistent manner and that exceptions that occur while
running a job to not error out the entire daemon process.
