### PR TITLE
Change `Daemon` state handling, rename to "signal"

### DIFF
--- a/test/unit/daemon_tests.rb
+++ b/test/unit/daemon_tests.rb
@@ -24,7 +24,7 @@ module Qs::Daemon
     should have_writers :check_for_signals_proc
 
     should have_imeths :start, :stop, :halt
-    should have_imeths :running?, :stopped?, :halted?
+    should have_imeths :running?
 
     should "return it's configuration's pid file with #pid_file" do
       assert_equal @daemon_class.configuration.pid_file, subject.pid_file
@@ -39,9 +39,7 @@ module Qs::Daemon
     end
 
     should "be stopped by default" do
-      assert subject.stopped?
       assert_not subject.running?
-      assert_not subject.halted?
     end
 
   end
@@ -55,10 +53,8 @@ module Qs::Daemon
       @daemon.stop
     end
 
-    should "set the daemon's state to running" do
+    should "be running" do
       assert subject.running?
-      assert_not subject.stopped?
-      assert_not subject.halted?
     end
 
     should "return a the daemon's work loop thread" do
@@ -71,6 +67,8 @@ module Qs::Daemon
   class CheckSignalProcTests < UnitTests
     desc "when given a check for signals proc and started"
     setup do
+      @daemon_class.wait_timeout 0
+      @daemon = @daemon_class.new
       @check_for_signals_proc_called = 0
       @daemon.check_for_signals_proc = proc{ @check_for_signals_proc_called += 1 }
       @thread = @daemon.start
@@ -174,11 +172,9 @@ module Qs::Daemon
       @daemon.stop
     end
 
-    should "set the daemon's state to stopped" do
+    should "no longer be running" do
       @thread.join(0.1)
-      assert subject.stopped?
       assert_not subject.running?
-      assert_not subject.halted?
     end
 
     should "stop the daemon's work loop thread" do
@@ -195,11 +191,9 @@ module Qs::Daemon
       @daemon.halt
     end
 
-    should "set the daemon's state to halted" do
+    should "no longer be running" do
       @thread.join(0.1)
-      assert subject.halted?
       assert_not subject.running?
-      assert_not subject.stopped?
     end
 
     should "stop the daemon's work loop thread" do

--- a/test/unit/process_tests.rb
+++ b/test/unit/process_tests.rb
@@ -116,7 +116,6 @@ class Qs::Process
 
       trap_call.block.call
       @process_thread.join
-      assert @daemon.stopped?
       assert_not @daemon.running?
     end
 
@@ -126,7 +125,6 @@ class Qs::Process
 
       trap_call.block.call
       @process_thread.join
-      assert @daemon.halted?
       assert_not @daemon.running?
     end
 
@@ -136,7 +134,6 @@ class Qs::Process
 
       trap_call.block.call
       @process_thread.join
-      assert @daemon.stopped?
       assert_not @daemon.running?
 
       # should have restarted the current process


### PR DESCRIPTION
This renames the `Daemon` state to signal and removes the public
query methods. This is a better name because the value represents
the last command or signal that was sent to the daemon. It doesn't
reflect it's current state. The public query methods of the
daemon's state are not needed outside of the daemon, they are only
used internally. The state of the daemon can be determined via the
`running?` boolean.

This also changes when the work loop checks for signals. This is
now done just before the loop iterates. This way we check for a
new signal and then immediately check if the state has changed.
Previously, the work loop would check for a signal, be stopped,
fetch one last job and then exit out of it's loop. This isn't the
preferred behavior, thus this change was made.
