### PR TITLE
Use dat-worker-pool's spy in the daemon tests

### DIFF
--- a/qs.gemspec
+++ b/qs.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency("dat-worker-pool", ["~> 0.2"])
+  gem.add_dependency("dat-worker-pool", ["~> 0.3"])
   gem.add_dependency("ns-options",      ["~> 1.1", ">= 1.1.4"])
 
   gem.add_development_dependency("assert")


### PR DESCRIPTION
This removes the custom dat-worker-pool spy and uses the one
provided by the gem. This also tweaks the testing to not build
an actual `DatWorkerPool` instance. This had the effect of `Qs`
testing `DatWorkerPool`'s behavior, which isn't necessary. This
switches to only testing `Qs` logic and relying on the spy.
