### PR TITLE
Simply CLI `Config` class

### DIFF
--- a/lib/qs/cli.rb
+++ b/lib/qs/cli.rb
@@ -1,5 +1,6 @@
 require 'qs/daemon'
 require 'qs/process'
+require 'qs/version'
 
 module Qs
 
@@ -46,7 +47,7 @@ module Qs
       @cli.parse!(*args)
       command          = @cli.args.pop || 'run'
       config_file_path = @cli.args.pop || 'config.qs'
-      daemon = Qs::Config.parse(config_file_path).daemon
+      daemon = Qs::Config.new(config_file_path).daemon
       Qs::Process.call(command, daemon)
     end
 
@@ -54,40 +55,35 @@ module Qs
 
   class Config
 
-    def self.parse(file_path)
-      self.new(file_path)
-    end
-
     # The `Config` evaluates the file and creates a proc using it's contents.
     # This is a trick borrowed from Rack. This is essentially converting a file
     # into a proc and then instance eval'ing it. This has a couple benefits and
     # produces a less confusing outcome:
     # * The obvious benefit is the file is evaluated in the context of this
-    #   `Config`. This allows the file to call `run` and kick-off running a Qs
-    #   process.
+    #   `Config`. This allows the file to call `run`, setting the Qs daemon to
+    #   be run.
     # * The other benefit is that the file's contents behave like they were a
-    #   proc defined by the user. Previously, when I instance eval'd the file
-    #   directly, any constants defined in it were namespaced by the instance
-    #   of the config, which is very confusing. I'm not sure what other
-    #   "effects" this might have had but I believe this is why Rack does it
-    #   this way. The proc is created in the `TOPLEVEL_BINDING` which is how the
-    #   constants are defined correctly using this method.
+    #   proc defined by the user. Instance eval'ing the file directly, makes any
+    #   constants defined in it namespaced by the instance of the config, which
+    #   is very confusing. Thus, the proc is created and eval'd in the
+    #   `TOPLEVEL_BINDING`, which defines the constants correctly.
+
+    attr_reader :daemon
 
     def initialize(file_path)
       @file_path = build_file_path(file_path)
       @daemon    = nil
       build_proc = eval("proc{ #{File.read(@file_path)} }", TOPLEVEL_BINDING, @file_path, 0)
       self.instance_eval(&build_proc)
+      validate!
     end
 
     def run(daemon)
       @daemon = daemon
     end
 
-    def daemon
-      if @daemon.kind_of?(Qs::Daemon)
-        @daemon
-      else
+    def validate!
+      if !@daemon.kind_of?(Qs::Daemon)
         raise NoDaemonError.new(@daemon, @file_path)
       end
     end

--- a/test/unit/cli_tests.rb
+++ b/test/unit/cli_tests.rb
@@ -3,6 +3,7 @@ require 'qs/cli'
 
 require 'qs/daemon'
 require 'qs/process'
+require 'qs/version'
 require 'test/support/spy'
 
 class Qs::CLI

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -14,9 +14,8 @@ class Qs::Config
     subject{ @config }
 
     should have_imeths :run, :daemon
-    should have_cmeths :parse
 
-    should "set the daemon with #run" do
+    should "set its daemon with #run" do
       my_daemon_class = Class.new{ include Qs::Daemon }
       my_daemon = my_daemon_class.new
       subject.run my_daemon
@@ -28,11 +27,6 @@ class Qs::Config
       assert_instance_of MyDaemon, subject.daemon
     end
 
-    should "build a new config file and return it with #parse" do
-      config = Qs::Config.parse(@file_path)
-      assert_instance_of Qs::Config, config
-    end
-
   end
 
   class WithoutQsTests < UnitTests
@@ -41,11 +35,11 @@ class Qs::Config
       @file_path = SUPPORT_PATH.join('config_files/valid')
     end
 
-    should "find the file and parse it" do
+    should "find the file and eval it" do
       config = nil
       assert_nothing_raised{ config = Qs::Config.new(@file_path) }
       # `MyDaemon` is defined in `valid.qs`
-      assert_instance_of MyDaemon, subject.daemon
+      assert_instance_of MyDaemon, config.daemon
     end
 
   end
@@ -82,12 +76,11 @@ class Qs::Config
     desc "with a config file that doesn't call `run`"
     setup do
       @file_path = SUPPORT_PATH.join('config_files/empty.qs')
-      @config    = Qs::Config.new(@file_path)
     end
 
     should "raise a NoDaemon error" do
       exception = nil
-      begin; subject.daemon; rescue Exception => exception; end
+      begin; Qs::Config.new(@file_path); rescue Exception => exception; end
       assert_instance_of Qs::Config::NoDaemonError, exception
       expected_message = "Configuration file #{@file_path.to_s.inspect} " \
                          "didn't call `run` with a Qs::Daemon"
@@ -97,15 +90,14 @@ class Qs::Config
   end
 
   class InvalidDaemonTests < UnitTests
-    desc "with a config file that calls `run` but not with a Qs::Daemon"
+    desc "with a config file that calls `run` but not with a daemon"
     setup do
       @file_path = SUPPORT_PATH.join('config_files/invalid.qs')
-      @config    = Qs::Config.new(@file_path)
     end
 
     should "raise a NoDaemon error" do
       exception = nil
-      begin; subject.daemon; rescue Exception => exception; end
+      begin; Qs::Config.new(@file_path); rescue Exception => exception; end
       assert_instance_of Qs::Config::NoDaemonError, exception
       expected_message = "Configuration file #{@file_path.to_s.inspect} " \
                          "called `run` without a Qs::Daemon"


### PR DESCRIPTION
This simplifies the CLI `Config` class by removing the extra
`parse` method and making it's validation clearer. Instead of
lazily validating when the `daemon` method is called, this
validates as part of building the class. This is a more
straightforward workflow and doesn't hinge on calling the
`daemon` method. The `parse` method was superfulous and this
reduces the "code debt" of Qs by removing it.
