### PR TITLE
Update to latest gem conventions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 gemspec
 
 gem 'rake'
-gem 'pry'
+gem 'pry', "~> 0.9.0"

--- a/qs.gemspec
+++ b/qs.gemspec
@@ -19,9 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency("dat-worker-pool", ["~> 0.3"])
-  gem.add_dependency("ns-options",      ["~> 1.1", ">= 1.1.4"])
+  gem.add_dependency("ns-options",      ["~> 1.1"])
 
-  gem.add_development_dependency("assert")
-  gem.add_development_dependency("assert-mocha")
-
+  gem.add_development_dependency("assert", ["~> 2.12"])
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -5,8 +5,8 @@
 $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 
 require 'pry' # require pry for debugging (`binding.pry`)
-require 'assert-mocha' if defined?(Assert)
 
 require 'pathname'
-ROOT         = Pathname.new(File.expand_path('../..', __FILE__))
-SUPPORT_PATH = ROOT.join('test/support')
+ROOT_PATH = Pathname.new(File.expand_path('../..', __FILE__))
+
+require 'test/support/factory'

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,0 +1,6 @@
+require 'assert/factory'
+
+module Factory
+  extend Assert::Factory
+
+end


### PR DESCRIPTION
This updates Qs to our latest gem conventions. This includes
updating its dependencies, specifically bringing in the latest
Assert and removing Assert-Mocha. Assert now has its own stubbing
tools so Assert-Mocha is no longer needed. This also adds a factory
which is just built off of Assert's factory. This will allow
generating random data and also provide a place for Qs to add its
own factory methods if needed. This is part of keeping Qs updated
to our latest conventions and part of maintaining it.

This doesn't update any of the tests or code though it normally
would. This is because this is also setup for a lot of work being
done on Qs. I'd rather not spend the time updating the tests when
I'm likely going to change them anyway. I'll update them as I
change and implement logic.

@kellyredding - Ready for review.
