### PR TITLE
Add `ProcessSignal` and `PIDFile`

### DIFF
--- a/lib/qs/pid_file.rb
+++ b/lib/qs/pid_file.rb
@@ -1,0 +1,42 @@
+require 'fileutils'
+
+module Qs
+
+  class PIDFile
+    attr_reader :path
+
+    def initialize(path)
+      @path = (path || '/dev/null').to_s
+    end
+
+    def pid
+      pid = File.read(@path).strip
+      pid && !pid.empty? ? pid.to_i : raise('no pid in file')
+    rescue StandardError => exception
+      error = InvalidError.new("A PID couldn't be read from #{@path.inspect}")
+      error.set_backtrace(exception.backtrace)
+      raise error
+    end
+
+    def write
+      FileUtils.mkdir_p(File.dirname(@path))
+      File.open(@path, 'w'){ |f| f.puts ::Process.pid }
+    rescue StandardError => exception
+      error = InvalidError.new("Can't write pid to file #{@path.inspect}")
+      error.set_backtrace(exception.backtrace)
+      raise error
+    end
+
+    def remove
+      FileUtils.rm_f(@path)
+    end
+
+    def to_s
+      @path
+    end
+
+    InvalidError = Class.new(RuntimeError)
+
+  end
+
+end

--- a/lib/qs/process_signal.rb
+++ b/lib/qs/process_signal.rb
@@ -1,6 +1,19 @@
+require 'qs/pid_file'
+
 module Qs
 
   class ProcessSignal
+
+    attr_reader :signal, :pid
+
+    def initialize(daemon, signal)
+      @signal = signal
+      @pid = PIDFile.new(daemon.pid_file).pid
+    end
+
+    def send
+      ::Process.kill(@signal, @pid)
+    end
 
   end
 

--- a/lib/qs/tmp_daemon.rb
+++ b/lib/qs/tmp_daemon.rb
@@ -2,6 +2,30 @@ module Qs
 
   module TmpDaemon
 
+    def self.included(klass)
+      klass.class_eval do
+        extend ClassMethods
+        include InstanceMethods
+      end
+    end
+
+    module InstanceMethods
+
+      def pid_file
+        self.class.pid_file
+      end
+
+    end
+
+    module ClassMethods
+
+      def pid_file(value = nil)
+        @pid_file = value unless value.nil?
+        @pid_file
+      end
+
+    end
+
   end
 
 end

--- a/test/support/pid_file_spy.rb
+++ b/test/support/pid_file_spy.rb
@@ -1,0 +1,19 @@
+class PIDFileSpy
+
+  attr_reader :pid, :write_called, :remove_called
+
+  def initialize(pid)
+    @pid = pid
+    @write_called = false
+    @remove_called = false
+  end
+
+  def write
+    @write_called = true
+  end
+
+  def remove
+    @remove_called = true
+  end
+
+end

--- a/test/unit/pid_file_tests.rb
+++ b/test/unit/pid_file_tests.rb
@@ -1,0 +1,70 @@
+require 'assert'
+require 'qs/pid_file'
+
+class Qs::PIDFile
+
+  class UnitTests < Assert::Context
+    desc "Qs::PIDFile"
+    setup do
+      @path = ROOT_PATH.join('tmp/pid_file_tests.pid').to_s
+      @pid_file = Qs::PIDFile.new(@path)
+    end
+    teardown do
+      FileUtils.rm_rf(@path)
+    end
+    subject{ @pid_file }
+
+    should have_readers :path
+    should have_imeths :pid, :write, :remove, :to_s
+
+    should "know its path" do
+      assert_equal @path, subject.path
+    end
+
+    should "default its path" do
+      pid_file = Qs::PIDFile.new(nil)
+      assert_equal '/dev/null', pid_file.path
+    end
+
+    should "know its string format" do
+      assert_equal @path, subject.to_s
+    end
+
+    should "read a PID from its file" do
+      pid = Factory.integer
+      File.open(@path, 'w'){ |f| f.puts pid }
+      assert_equal pid, subject.pid
+    end
+
+    should "raise an invalid error when it can't read from its file" do
+      FileUtils.rm_rf(@path)
+      assert_raises(InvalidError){ subject.pid }
+    end
+
+    should "raise an invalid error when the file doesn't have a PID in it" do
+      File.open(@path, 'w'){ |f| f.puts '' }
+      assert_raises(InvalidError){ subject.pid }
+    end
+
+    should "write the process PID to its file" do
+      assert_false File.exists?(@path)
+      subject.write
+      assert_true File.exists?(@path)
+      assert_equal "#{::Process.pid}\n", File.read(@path)
+    end
+
+    should "raise an invalid error when it can't write its file" do
+      Assert.stub(File, :open){ raise "can't open file" }
+      assert_raises(InvalidError){ subject.write }
+    end
+
+    should "remove its file" do
+      FileUtils.touch(@path)
+      assert_true File.exists?(@path)
+      subject.remove
+      assert_false File.exists?(@path)
+    end
+
+  end
+
+end

--- a/test/unit/process_signal_tests.rb
+++ b/test/unit/process_signal_tests.rb
@@ -1,0 +1,58 @@
+require 'assert'
+require 'qs/process_signal'
+
+require 'qs/tmp_daemon'
+require 'test/support/pid_file_spy'
+
+class Qs::ProcessSignal
+
+  class UnitTests < Assert::Context
+    desc "Qs::ProcessSignal"
+    setup do
+      @daemon = TestDaemon.new
+      @signal = Factory.string
+
+      @pid_file_spy = PIDFileSpy.new(Factory.integer)
+      Assert.stub(Qs::PIDFile, :new).with(@daemon.pid_file) do
+        @pid_file_spy
+      end
+
+      @process_signal = Qs::ProcessSignal.new(@daemon, @signal)
+    end
+    subject{ @process_signal }
+
+    should have_readers :signal, :pid
+    should have_imeths :send
+
+    should "know its signal and pid" do
+      assert_equal @signal, subject.signal
+      assert_equal @pid_file_spy.pid, subject.pid
+    end
+
+  end
+
+  class SendTests < UnitTests
+    desc "when sent"
+    setup do
+      @kill_called = false
+      Assert.stub(::Process, :kill).with(@signal, @pid_file_spy.pid) do
+        @kill_called = true
+      end
+
+      @process_signal.send
+    end
+
+    should "have used process kill to send the signal to the PID" do
+      assert_true @kill_called
+    end
+
+  end
+
+  class TestDaemon
+    include Qs::TmpDaemon
+
+    pid_file Factory.file_path
+
+  end
+
+end


### PR DESCRIPTION
This fills out the `ProcessSignal` class and adds a `PIDFile`
class. The `ProcessSignal` is used to manage a running Qs process.
It uses the configured pid file path to read the pid of the running
process and sends a signal to it. This is used by the `CLI` to
stop or restart a Qs process. The `PIDFile` is an internal tool
that handles reading, writing and removing pid files for the
`Process` and `ProcessSignal`. In a separate commit, I will update
the `Process` to use this `PIDFile` as well.

@kellyredding - Ready for review. More stuff from Sanford.
