### PR TITLE
Add `Queue` and `Route`

### DIFF
--- a/lib/qs/queue.rb
+++ b/lib/qs/queue.rb
@@ -1,19 +1,49 @@
-require 'logger'
+require 'qs/route'
 
-module Qs; end
-class Qs::Queue
+module Qs
 
-  # This is temporary, just defining what a daemon needs from a queue
-  attr_accessor :name, :logger, :mappings
+  class Queue
 
-  def initialize
-    @logger ||= Logger.new(File.open("/dev/null", 'w'))
-    @mappings = []
-  end
+    attr_reader :routes
 
-  def fetch_job(timeout = nil)
-    sleep(timeout) if timeout
-    'test'
+    def initialize(&block)
+      @job_handler_ns = nil
+      @routes = []
+      self.instance_eval(&block) if !block.nil?
+      raise InvalidError, "a queue must have a name" if self.name.nil?
+    end
+
+    def name(value = nil)
+      @name = value if !value.nil?
+      @name
+    end
+
+    def redis_key
+      "queues:#{@name}"
+    end
+
+    def job_handler_ns(value = nil)
+      @job_handler_ns = value if !value.nil?
+      @job_handler_ns
+    end
+
+    def job(name, handler_name)
+      if self.job_handler_ns && !(handler_name =~ /^::/)
+        handler_name = "#{self.job_handler_ns}::#{handler_name}"
+      end
+
+      @routes.push(Qs::Route.new(name, handler_name))
+    end
+
+    def inspect
+      reference = '0x0%x' % (self.object_id << 1)
+      "#<#{self.class}:#{reference} " \
+        "@name=#{self.name.inspect} " \
+        "@job_handler_ns=#{self.job_handler_ns.inspect}>"
+    end
+
+    InvalidError = Class.new(RuntimeError)
+
   end
 
 end

--- a/lib/qs/route.rb
+++ b/lib/qs/route.rb
@@ -1,0 +1,46 @@
+module Qs
+
+  class Route
+
+    attr_reader :name, :handler_class_name, :handler_class
+
+    def initialize(name, handler_class_name)
+      @name = name.to_s
+      @handler_class_name = handler_class_name
+      @handler_class = nil
+    end
+
+    def validate!
+      @handler_class = constantize_handler_class(@handler_class_name)
+    end
+
+    def run
+      # TODO
+    end
+
+    private
+
+    def constantize_handler_class(handler_class_name)
+      constantize(handler_class_name).tap do |handler_class|
+        raise(NoHandlerClassError.new(handler_class_name)) if !handler_class
+      end
+    end
+
+    def constantize(class_name)
+      names = class_name.to_s.split('::').reject{ |name| name.empty? }
+      klass = names.inject(Object){ |constant, name| constant.const_get(name) }
+      klass == Object ? false : klass
+    rescue NameError
+      false
+    end
+
+  end
+
+  class NoHandlerClassError < RuntimeError
+    def initialize(handler_class_name)
+      super "Qs couldn't find the handler '#{handler_class_name}'" \
+            " - it doesn't exist or hasn't been required in yet."
+    end
+  end
+
+end

--- a/test/unit/queue_tests.rb
+++ b/test/unit/queue_tests.rb
@@ -1,0 +1,82 @@
+require 'assert'
+require 'qs/queue'
+
+require 'test/support/factory'
+
+class Qs::Queue
+
+  class UnitTests < Assert::Context
+    desc "Qs::Queue"
+    setup do
+      @queue = Qs::Queue.new do
+        name Factory.string
+      end
+    end
+    subject{ @queue }
+
+    should have_readers :routes
+    should have_imeths :name, :redis_key, :job_handler_ns, :job
+
+    should "build an empty array for its routes by default" do
+      assert_equal [], subject.routes
+    end
+
+    should "allow setting its name" do
+      name = Factory.string
+      subject.name name
+      assert_equal name, subject.name
+    end
+
+    should "know its redis key" do
+      assert_equal "queues:#{subject.name}", subject.redis_key
+    end
+
+    should "not have a job handler ns by default" do
+      assert_nil subject.job_handler_ns
+    end
+
+    should "allow setting its job handler ns" do
+      namespace = Factory.string
+      subject.job_handler_ns namespace
+      assert_equal namespace, subject.job_handler_ns
+    end
+
+    should "allow adding routes using `job`" do
+      job_name = Factory.string
+      handler_name = Factory.string
+      subject.job job_name, handler_name
+
+      route = subject.routes.last
+      assert_instance_of Qs::Route, route
+      assert_equal job_name, route.name
+      assert_equal handler_name, route.handler_class_name
+    end
+
+    should "use its job handler ns when adding routes" do
+      namespace = Factory.string
+      subject.job_handler_ns namespace
+
+      job_name = Factory.string
+      handler_name = Factory.string
+      subject.job job_name, handler_name
+
+      route = subject.routes.last
+      expected = "#{namespace}::#{handler_name}"
+      assert_equal expected, route.handler_class_name
+    end
+
+    should "know its custom inspect" do
+      reference = '0x0%x' % (subject.object_id << 1)
+      expected = "#<#{subject.class}:#{reference} " \
+                   "@name=#{subject.name.inspect} " \
+                   "@job_handler_ns=#{subject.job_handler_ns.inspect}>"
+      assert_equal expected, subject.inspect
+    end
+
+    should "require a name when initialized" do
+      assert_raises(InvalidError){ Qs::Queue.new }
+    end
+
+  end
+
+end

--- a/test/unit/route_tests.rb
+++ b/test/unit/route_tests.rb
@@ -1,0 +1,53 @@
+require 'assert'
+require 'qs/route'
+
+class Qs::Route
+
+  class UnitTests < Assert::Context
+    desc "Qs::Route"
+    setup do
+      @name = Factory.string
+      @handler_class_name = TestHandler.to_s
+      @route = Qs::Route.new(@name, @handler_class_name)
+    end
+    subject{ @route }
+
+    should have_readers :name, :handler_class_name, :handler_class
+    should have_imeths :validate!, :run
+
+    should "know its name and handler class name" do
+      assert_equal @name, subject.name
+      assert_equal @handler_class_name, subject.handler_class_name
+    end
+
+    should "not know its handler class by default" do
+      assert_nil subject.handler_class
+    end
+
+    should "constantize its handler class after being validated" do
+      subject.validate!
+      assert_equal TestHandler, subject.handler_class
+    end
+
+  end
+
+  class RunTests < UnitTests
+    desc "when run"
+
+  end
+
+  class InvalidHandlerClassNameTests < UnitTests
+    desc "with an invalid handler class name"
+    setup do
+      @route = Qs::Route.new(@name, Factory.string)
+    end
+
+    should "raise a no handler class error when validated" do
+      assert_raises(Qs::NoHandlerClassError){ subject.validate! }
+    end
+
+  end
+
+  TestHandler = Class.new
+
+end


### PR DESCRIPTION
define queues and add routes to them. The queue is where job
routes are defined and also knows its redis key. This will be
used when adding jobs to the queue and reading jobs that need to
be processed. Routes are a name and a handler class name. When
a route is validated, the handler class name is constantized.
This will be done when a daemon is started so it can quickly route
and run jobs when they are pulled off of redis.

@kellyredding - Ready for review.
