### PR TITLE
Update and simplify `Process`

### DIFF
--- a/lib/qs/cli.rb
+++ b/lib/qs/cli.rb
@@ -1,6 +1,6 @@
 require 'qs'
 require 'qs/config_file'
-require 'qs/tmp_process'
+require 'qs/process'
 require 'qs/process_signal'
 require 'qs/version'
 
@@ -46,9 +46,9 @@ module Qs
       daemon = Qs::ConfigFile.new(config_file_path).daemon
       case(command)
       when 'run'
-        Qs::TmpProcess.new(daemon, :daemonize => false).run
+        Qs::Process.new(daemon, :daemonize => false).run
       when 'start'
-        Qs::TmpProcess.new(daemon, :daemonize => true).run
+        Qs::Process.new(daemon, :daemonize => true).run
       when 'stop'
         Qs::ProcessSignal.new(daemon, 'TERM').send
       when 'restart'

--- a/lib/qs/process.rb
+++ b/lib/qs/process.rb
@@ -1,195 +1,135 @@
-require 'fileutils'
+require 'qs/pid_file'
 
 module Qs
 
   class Process
 
-    InvalidError = Class.new(StandardError)
+    attr_reader :daemon, :name, :pid_file, :restart_cmd
 
-    def self.call(command, daemon)
-      self.new(daemon).call(command)
-    end
-
-    def initialize(daemon)
-      @daemon   = daemon
+    def initialize(daemon, options = nil)
+      options ||= {}
+      @daemon = daemon
+      @logger = @daemon.logger
       @pid_file = PIDFile.new(@daemon.pid_file)
+      @restart_cmd = RestartCmd.new
+
+      @name = ignore_if_blank(ENV['QS_PROCESS_NAME']) || "qs-#{@daemon.name}"
+
+      @daemonize = !!options[:daemonize]
+      @skip_daemonize = !!ignore_if_blank(ENV['QS_SKIP_DAEMONIZE'])
+      @restart = false
     end
 
-    def call(command)
-      case command.to_sym
-      when :run
-        DaemonHandler.run(@daemon, @pid_file, false)
-      when :start
-        DaemonHandler.run(@daemon, @pid_file, true)
-      when :stop
-        Signal.send("TERM", @pid_file.pid)
-      when :restart
-        Signal.send("USR2", @pid_file.pid)
+    def run
+      ::Process.daemon(true) if self.daemonize?
+      log "Starting Qs daemon for #{@daemon.name}..."
+
+      $0 = @name
+      @pid_file.write
+      log "PID: #{@pid_file.pid}"
+
+      ::Signal.trap("TERM"){ @daemon.stop }
+      ::Signal.trap("INT"){ @daemon.halt }
+      ::Signal.trap("USR2") do
+        @daemon.stop
+        @restart = true
+      end
+
+      thread = @daemon.start
+      log "#{@daemon.name} daemon started and ready."
+      thread.join
+      exec_restart_cmd if self.restart?
+    rescue StandardError => exception
+      log "Error: #{exception.message}"
+      log "#{@daemon.name} daemon never started."
+    ensure
+      @pid_file.remove
+    end
+
+    def daemonize?
+      @daemonize && !@skip_daemonize
+    end
+
+    def restart?
+      @restart
+    end
+
+    private
+
+    def log(message)
+      @logger.info "[Qs] #{message}"
+    end
+
+    def exec_restart_cmd
+      log "Restarting #{@daemon.name} daemon..."
+      ENV['QS_SKIP_DAEMONIZE'] = 'yes'
+      @restart_cmd.exec
+    end
+
+    def default_if_blank(value, default, &block)
+      ignore_if_blank(value, &block) || default
+    end
+
+    def ignore_if_blank(value, &block)
+      block ||= proc{ |v| v }
+      block.call(value) if value && !value.empty?
+    end
+
+  end
+
+  class RestartCmd
+    attr_reader :argv, :dir
+
+    def initialize
+      require 'rubygems'
+      @dir  = get_pwd
+      @argv = [ Gem.ruby, $0, ARGV.dup ].flatten
+    end
+
+    def exec
+      Dir.chdir self.dir
+      Kernel.exec(*self.argv)
+    end
+
+    protected
+
+    # Trick from puma/unicorn. Favor PWD because it contains an unresolved
+    # symlink. This is useful when restarting after deploying; the original
+    # directory may be removed, but the symlink is pointing to a new
+    # directory.
+    def get_pwd
+      env_stat = File.stat(ENV['PWD'])
+      pwd_stat = File.stat(Dir.pwd)
+      if env_stat.ino == pwd_stat.ino && env_stat.dev == pwd_stat.dev
+        ENV['PWD']
       else
-        raise InvalidError, "Unknown command: #{command.inspect}"
+        Dir.pwd
       end
     end
+  end
 
-    class DaemonHandler
-      def self.run(daemon, pid_file, daemonize_process)
-        self.new(daemon, pid_file).run(daemonize_process)
-      end
-
-      def initialize(daemon, pid_file)
-        @daemon       = daemon
-        @queue_name   = @daemon.queue_name
-        @logger       = @daemon.logger
-        @pid_file     = pid_file
-        @process_name = ProcessName.new(@queue_name)
-        @restart_cmd  = RestartCmd.new
-        @signal = nil
-        @signal_queue = []
-      end
-
-      def run(daemonize = false)
-        daemonize!(true) if daemonize && !ENV['QS_SKIP_DAEMONIZE']
-        log "Starting Qs daemon for #{@queue_name}..."
-        $0 = @process_name
-        @pid_file.write
-        log "PID: #{::Process.pid}"
-
-        @daemon.check_for_signals_proc = proc{ check_signal_queue }
-        ::Signal.trap("TERM"){ @signal_queue << :stop }
-        ::Signal.trap("INT"){  @signal_queue << :halt }
-        ::Signal.trap("USR2"){ @signal_queue << :restart }
-
-        thread = @daemon.start
-        log "#{@queue_name} daemon started and ready."
-        thread.join
-        restart if @signal == :restart
-      rescue RuntimeError => exception
-        log "Error: #{exception.message}"
-        log "#{@queue_name} daemon never started."
-      ensure
-        @pid_file.remove
-      end
-
-      private
-
-      def log(message)
-        @logger.info "[Qs] #{message}"
-      end
-
-      def check_signal_queue
-        @signal = @signal_queue.pop
-        case @signal
-        when :stop, :restart
-          @daemon.stop
-        when :halt
-          @daemon.halt
-        end
-      end
-
-      def restart
-        log "Restarting #{@queue_name} daemon..."
-        ENV['QS_SKIP_DAEMONIZE'] = 'yes'
-        Dir.chdir @restart_cmd.dir
-        Kernel.exec(*@restart_cmd.argv)
-      end
+  # This is from puma for 1.8 compatibility. Ruby 1.9+ defines a
+  # `Process.daemon` for daemonizing processes. This defines the method when it
+  # isn't provided, i.e. Ruby 1.8.
+  unless ::Process.respond_to?(:daemon)
+    ::Process.class_eval do
 
       # Full explanation: http://www.steve.org.uk/Reference/Unix/faq_2.html#SEC16
-      def daemonize!(no_chdir = false, no_close = false)
+      def self.daemon(no_chdir = false, no_close = false)
         exit if fork
-        Process.setsid
+        ::Process.setsid
         exit if fork
-        Dir.chdir "/" unless no_chdir
+        Dir.chdir '/' unless no_chdir
         if !no_close
-          null = File.open "/dev/null", 'w'
+          null = File.open('/dev/null', 'w')
           STDIN.reopen null
           STDOUT.reopen null
           STDERR.reopen null
         end
         return 0
       end
+
     end
-
-    class Signal
-      def self.send(signal, pid)
-        self.new(signal).send_to(pid)
-      end
-
-      def initialize(signal)
-        @signal = signal
-      end
-
-      def send_to(pid)
-        ::Process.kill(@signal, pid)
-      end
-    end
-
-    class PIDFile
-      attr_reader :path
-
-      def initialize(path)
-        @path = (path || '/dev/null').to_s
-      end
-
-      def pid
-        pid = File.read(@path).strip
-        pid && !pid.empty? ? pid.to_i : raise('no pid in file')
-      rescue Exception => exception
-        error = InvalidError.new("A PID couldn't be read from #{@path.inspect}")
-        error.set_backtrace(exception.backtrace)
-        raise error
-      end
-
-      def write
-        begin
-          FileUtils.mkdir_p(File.dirname(@path))
-          File.open(@path, 'w'){ |f| f.puts ::Process.pid }
-        rescue Exception => exception
-          error = InvalidError.new("Can't write pid to file #{@path.inspect}")
-          error.set_backtrace(exception.backtrace)
-          raise error
-        end
-      end
-
-      def remove
-        FileUtils.rm_f(@path)
-      end
-
-      def to_s
-        @path
-      end
-    end
-
-    class ProcessName < String
-      def initialize(queue_name)
-        super "qs_#{queue_name}"
-      end
-    end
-
-    class RestartCmd
-      attr_reader :argv, :dir
-
-      def initialize
-        require 'rubygems'
-        @dir  = get_pwd
-        @argv = [ Gem.ruby, $0, ARGV.dup ].flatten
-      end
-
-      protected
-
-      # Trick from puma/unicorn. Favor PWD because it contains an unresolved
-      # symlink. This is useful when restarting after deploying; the original
-      # directory may be removed, but the symlink is pointing to a new
-      # directory.
-      def get_pwd
-        env_stat = File.stat(ENV['PWD'])
-        pwd_stat = File.stat(Dir.pwd)
-        if env_stat.ino == pwd_stat.ino && env_stat.dev == pwd_stat.dev
-          ENV['PWD']
-        else
-          Dir.pwd
-        end
-      end
-    end
-
   end
 
 end

--- a/lib/qs/tmp_daemon.rb
+++ b/lib/qs/tmp_daemon.rb
@@ -1,3 +1,5 @@
+require 'logger'
+
 module Qs
 
   module TmpDaemon
@@ -11,6 +13,14 @@ module Qs
 
     module InstanceMethods
 
+      def name
+        self.class.name
+      end
+
+      def logger
+        self.class.logger
+      end
+
       def pid_file
         self.class.pid_file
       end
@@ -18,6 +28,16 @@ module Qs
     end
 
     module ClassMethods
+
+      def name(value = nil)
+        @name = value unless value.nil?
+        @name
+      end
+
+      def logger(value = nil)
+        @logger = value unless value.nil?
+        @logger || ::Logger.new('/dev/null')
+      end
 
       def pid_file(value = nil)
         @pid_file = value unless value.nil?

--- a/lib/qs/tmp_process.rb
+++ b/lib/qs/tmp_process.rb
@@ -1,7 +1,0 @@
-module Qs
-
-  class TmpProcess
-
-  end
-
-end

--- a/test/unit/cli_tests.rb
+++ b/test/unit/cli_tests.rb
@@ -38,7 +38,7 @@ class Qs::CLI
     setup do
       file_path = 'config.qs'
       Assert.stub(Qs::ConfigFile, :new).with(file_path){ @config_file }
-      Assert.stub(Qs::TmpProcess, :new).with(@daemon, :daemonize => false) do
+      Assert.stub(Qs::Process, :new).with(@daemon, :daemonize => false) do
         @process_spy
       end
 
@@ -54,7 +54,7 @@ class Qs::CLI
   class RunTests < CommandTests
     desc "with the run command"
     setup do
-      Assert.stub(Qs::TmpProcess, :new).with(@daemon, :daemonize => false) do
+      Assert.stub(Qs::Process, :new).with(@daemon, :daemonize => false) do
         @process_spy
       end
 
@@ -70,7 +70,7 @@ class Qs::CLI
   class StartTests < CommandTests
     desc "with the start command"
     setup do
-      Assert.stub(Qs::TmpProcess, :new).with(@daemon, :daemonize => true) do
+      Assert.stub(Qs::Process, :new).with(@daemon, :daemonize => true) do
         @process_spy
       end
 


### PR DESCRIPTION
This updates and simplifies the `Process` class. It removes all
the signal logic it had as this is now handled by the
`ProcessSignal`. This also removes the `PIDFile` logic that was
an internal helper in the file. It is now its own separate file
that it just requires. The `Process` is now only about running
a daemon and handling restarting it.

This also removes the tmp process file and switches the cli to
using the real one. This was a temporary placeholder while logic
was being reworked.

@kellyredding - Ready for review. This is gonna be another rough diff to look at. It's very similar to Sanford's process but is slightly simpler because it doesn't handle having an ip/port or file descriptor.
