### PR TITLE
Add `Logger` and `NullLogger`

### DIFF
--- a/lib/qs/logger.rb
+++ b/lib/qs/logger.rb
@@ -1,0 +1,23 @@
+module Qs
+
+  class Logger
+    attr_reader :summary, :verbose
+
+    def initialize(logger, verbose = true)
+      loggers = [logger, Qs::NullLogger.new]
+      loggers.reverse! if !verbose
+      @verbose, @summary = loggers
+    end
+
+  end
+
+  class NullLogger
+    require 'logger'
+
+    ::Logger::Severity.constants.each do |name|
+      define_method(name.downcase){ |*args| } # no-op
+    end
+
+  end
+
+end

--- a/test/unit/logger_tests.rb
+++ b/test/unit/logger_tests.rb
@@ -1,0 +1,38 @@
+require 'assert'
+require 'qs/logger'
+
+class Qs::Logger
+
+  class UnitTests < Assert::Context
+    desc "Qs::Logger"
+    setup do
+      @real_logger = Factory.string
+    end
+    subject{ Qs::Logger }
+
+    should "set its loggers correctly in summary mode" do
+      logger = subject.new(@real_logger, false)
+      assert_equal @real_logger, logger.summary
+      assert_instance_of Qs::NullLogger, logger.verbose
+    end
+
+    should "set its loggers correctly in verbose mode" do
+      logger = subject.new(@real_logger, true)
+      assert_instance_of Qs::NullLogger, logger.summary
+      assert_equal @real_logger, logger.verbose
+    end
+
+  end
+
+  class NullLoggerTests < Assert::Context
+    desc "Qs::NullLogger"
+    setup do
+      @null_logger = Qs::NullLogger.new
+    end
+    subject{ @null_logger }
+
+    should have_imeths :debug, :info, :error
+
+  end
+
+end


### PR DESCRIPTION
This adds a `Logger` utility and a `NullLogger`. These will be
used to handle summary and verbose logging. This uses a null
pattern depending for whichever logging is not "turned on". In
verbose mode, the summary method returns a null logger which will
accept all the logging calls but won't do anything with them. When
in summary mode, this is reversed.

@kellyredding - Ready for review. 
