### PR TITLE
Add `DaemonData`

### DIFF
--- a/lib/qs/daemon_data.rb
+++ b/lib/qs/daemon_data.rb
@@ -1,0 +1,46 @@
+module Qs
+
+  class DaemonData
+
+    # The daemon uses this to "compile" its configuration for speed. NsOptions
+    # is relatively slow everytime an option is read. To avoid this, we read the
+    # options one time here and memoize their values. This way, we don't pay the
+    # NsOptions overhead when reading them while handling a job.
+
+    attr_reader :name
+    attr_reader :pid_file
+    attr_reader :min_workers, :max_workers
+    attr_reader :logger, :verbose_logging
+    attr_reader :shutdown_timeout
+    attr_reader :error_procs
+    attr_reader :queue_redis_keys, :routes
+
+    def initialize(args = nil)
+      args ||= {}
+      @name = args[:name]
+      @pid_file = args[:pid_file]
+      @min_workers = args[:min_workers]
+      @max_workers = args[:max_workers]
+      @logger = args[:logger]
+      @verbose_logging = !!args[:verbose_logging]
+      @shutdown_timeout = args[:shutdown_timeout]
+      @error_procs = args[:error_procs] || []
+      @queue_redis_keys = args[:queue_redis_keys] || []
+      @routes = build_routes(args[:routes] || [])
+    end
+
+    def route_for(name)
+      @routes[name] || raise(NotFoundError, "no service named '#{name}'")
+    end
+
+    private
+
+    def build_routes(routes)
+      routes.inject({}){ |h, route| h.merge(route.name => route) }
+    end
+
+  end
+
+  NotFoundError = Class.new(RuntimeError)
+
+end

--- a/test/unit/daemon_data_tests.rb
+++ b/test/unit/daemon_data_tests.rb
@@ -1,0 +1,96 @@
+require 'assert'
+require 'qs/daemon_data'
+
+require 'qs/queue'
+require 'qs/route'
+
+class Qs::DaemonData
+
+  class UnitTests < Assert::Context
+    desc "Qs::DaemonData"
+    setup do
+      @name = Factory.string
+      @pid_file = Factory.file_path
+      @min_workers = Factory.integer
+      @max_workers = Factory.integer
+      @logger = Factory.string
+      @verbose_logging = Factory.boolean
+      @shutdown_timeout = Factory.integer
+      @error_procs = [ proc{ Factory.string } ]
+      @queue_redis_keys = (0..Factory.integer(3)).map{ Factory.string }
+      @routes = (0..Factory.integer(3)).map do
+        Qs::Route.new(Factory.string, TestHandler.to_s).tap(&:validate!)
+      end
+
+      @daemon_data = Qs::DaemonData.new({
+        :name => @name,
+        :pid_file => @pid_file,
+        :min_workers => @min_workers,
+        :max_workers => @max_workers,
+        :logger => @logger,
+        :verbose_logging => @verbose_logging,
+        :shutdown_timeout => @shutdown_timeout,
+        :error_procs => @error_procs,
+        :queue_redis_keys => @queue_redis_keys,
+        :routes => @routes
+      })
+    end
+    subject{ @daemon_data }
+
+    should have_readers :name
+    should have_readers :pid_file
+    should have_readers :min_workers, :max_workers
+    should have_readers :logger, :verbose_logging
+    should have_readers :shutdown_timeout
+    should have_readers :error_procs
+    should have_readers :queue_redis_keys, :routes
+    should have_imeths :route_for
+
+    should "know its attributes" do
+      assert_equal @name, subject.name
+      assert_equal @pid_file, subject.pid_file
+      assert_equal @min_workers, subject.min_workers
+      assert_equal @max_workers, subject.max_workers
+      assert_equal @logger, subject.logger
+      assert_equal @verbose_logging, subject.verbose_logging
+      assert_equal @shutdown_timeout, subject.shutdown_timeout
+      assert_equal @error_procs, subject.error_procs
+      assert_equal @queue_redis_keys, subject.queue_redis_keys
+    end
+
+    should "build a routes lookup hash" do
+      expected = @routes.inject({}){ |h, r| h.merge(r.name => r) }
+      assert_equal expected, subject.routes
+    end
+
+    should "allow looking up a route using `route_for`" do
+      expected = @routes.choice
+      route = subject.route_for(expected.name)
+      assert_equal expected, route
+    end
+
+    should "raise a not found error using `route_for` with an invalid name" do
+      assert_raises(Qs::NotFoundError) do
+        subject.route_for(Factory.string)
+      end
+    end
+
+    should "default its attributes when they aren't provided" do
+      daemon_data = Qs::DaemonData.new
+      assert_nil daemon_data.name
+      assert_nil daemon_data.pid_file
+      assert_nil daemon_data.min_workers
+      assert_nil daemon_data.max_workers
+      assert_nil daemon_data.logger
+      assert_false daemon_data.verbose_logging
+      assert_nil daemon_data.shutdown_timeout
+      assert_equal [], daemon_data.error_procs
+      assert_equal [], daemon_data.queue_redis_keys
+      assert_equal({}, daemon_data.routes)
+    end
+
+  end
+
+  TestHandler = Class.new
+
+end


### PR DESCRIPTION
This adds a `DaemonData` class which handles "compiling" a daemons
configuration. This is done for speed and to provide a simple
object for passing around the daemon configuration. This also
provides methods for easily looking up a route, which will be used
to run a job handler.

@kellyredding - Ready for review. Same concept as Sanford's `ServerData`.
