### PR TITLE
Add Redis configuration and connection

### DIFF
--- a/lib/qs.rb
+++ b/lib/qs.rb
@@ -1,5 +1,53 @@
+require 'ns-options'
 require 'qs/version'
+require 'qs/redis_connection'
 
 module Qs
-  # TODO: your code goes here...
+
+  def self.config; @config ||= Config.new; end
+  def self.configure(&block)
+    block.call(self.config)
+  end
+
+  def self.init
+    self.config.redis.url ||= RedisUrl.new(
+      self.config.redis.ip,
+      self.config.redis.port,
+      self.config.redis.db
+    )
+    @redis = RedisConnection.new(self.redis_config)
+  end
+
+  def self.redis
+    @redis
+  end
+
+  def self.redis_config
+    self.config.redis.to_hash
+  end
+
+  class Config
+    include NsOptions::Proxy
+
+    namespace :redis do
+      option :ip,   :default => 'localhost'
+      option :port, :default => 6379
+      option :db,   :default => 0
+
+      option :url
+
+      option :redis_ns, String,  :default => 'qs'
+      option :driver,   String,  :default => 'ruby'
+      option :timeout,  Integer, :default => 1
+      option :size,     Integer, :default => 4
+    end
+  end
+
+  module RedisUrl
+    def self.new(ip, port, db)
+      return if ip.to_s.empty? || port.to_s.empty? || db.to_s.empty?
+      "redis://#{ip}:#{port}/#{db}"
+    end
+  end
+
 end

--- a/lib/qs/redis_connection.rb
+++ b/lib/qs/redis_connection.rb
@@ -1,0 +1,28 @@
+require 'hella-redis'
+
+module Qs
+
+  module RedisConnection
+
+    def self.new(options)
+      config = Config.new(options)
+      HellaRedis::RedisConnection.new(config)
+    end
+
+    class Config
+      attr_reader :url, :redis_ns
+      attr_reader :driver
+      attr_reader :timeout, :size
+
+      def initialize(options)
+        @url      = options[:url]
+        @redis_ns = options[:redis_ns]
+        @driver   = options[:driver]
+        @timeout  = options[:timeout]
+        @size     = options[:size]
+      end
+    end
+
+  end
+
+end

--- a/qs.gemspec
+++ b/qs.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency("dat-worker-pool", ["~> 0.3"])
+  gem.add_dependency("hella-redis",     ["~> 0.1"])
   gem.add_dependency("ns-options",      ["~> 1.1"])
 
   gem.add_development_dependency("assert", ["~> 2.12"])

--- a/test/unit/qs_tests.rb
+++ b/test/unit/qs_tests.rb
@@ -1,0 +1,111 @@
+require 'assert'
+require 'qs'
+
+require 'ns-options/assert_macros'
+
+module Qs
+
+  class UnitTests < Assert::Context
+    desc "Qs"
+    setup do
+      @current_config = Qs.config
+      @current_redis  = Qs.redis
+      Qs.instance_variable_set("@config", nil)
+      Qs.instance_variable_set("@redis", nil)
+
+      @module = Qs
+    end
+    teardown do
+      Qs.instance_variable_set("@redis", @current_redis)
+      Qs.instance_variable_set("@config", @current_config)
+    end
+    subject{ @module }
+
+    should have_imeths :config, :configure
+    should have_imeths :init, :redis, :redis_config
+
+    should "know its config" do
+      assert_instance_of Config, subject.config
+    end
+
+    should "allow configuring its config" do
+      yielded = nil
+      subject.configure{ |c| yielded = c }
+      assert_equal subject.config, yielded
+    end
+
+    should "not have a redis connection by default" do
+      assert_nil subject.redis
+    end
+
+    should "know its redis config" do
+      expected = subject.config.redis.to_hash
+      assert_equal expected, subject.redis_config
+    end
+
+    should "set its configured redis url when init" do
+      subject.config.redis.ip   = Factory.string
+      subject.config.redis.port = Factory.integer
+      subject.config.redis.db   = Factory.integer
+      subject.init
+
+      expected = RedisUrl.new(
+        subject.config.redis.ip,
+        subject.config.redis.port,
+        subject.config.redis.db
+      )
+      assert_equal expected, subject.config.redis.url
+    end
+
+    should "set its redis connection when init" do
+      subject.init
+      assert_instance_of ConnectionPool, subject.redis
+    end
+
+  end
+
+  class ConfigTests < UnitTests
+    include NsOptions::AssertMacros
+
+    desc "Config"
+    setup do
+      @config = Config.new
+    end
+    subject{ @config }
+
+    should have_namespace :redis
+
+    should "know its redis options" do
+      assert_equal 'localhost', subject.redis.ip
+      assert_equal 6379, subject.redis.port
+      assert_equal 0, subject.redis.db
+      assert_nil subject.redis.url
+      assert_equal 'qs', subject.redis.redis_ns
+      assert_equal 'ruby', subject.redis.driver
+      assert_equal 1, subject.redis.timeout
+      assert_equal 4, subject.redis.size
+    end
+
+  end
+
+  class RedisUrlTests < UnitTests
+    desc "RedisUrl"
+    subject{ RedisUrl }
+
+    should "build a redis url when passed an ip, port and db" do
+      ip = Factory.string
+      port = Factory.integer
+      db = Factory.integer
+      expected = "redis://#{ip}:#{port}/#{db}"
+      assert_equal expected, subject.new(ip, port, db)
+    end
+
+    should "not return a url with an ip, port or db" do
+      assert_nil subject.new(nil, Factory.integer, Factory.integer)
+      assert_nil subject.new(Factory.string, nil, Factory.integer)
+      assert_nil subject.new(Factory.string, Factory.integer, nil)
+    end
+
+  end
+
+end

--- a/test/unit/redis_connection_tests.rb
+++ b/test/unit/redis_connection_tests.rb
@@ -1,0 +1,38 @@
+require 'assert'
+require 'qs/redis_connection'
+
+module Qs::RedisConnection
+
+  class UnitTests < Assert::Context
+    desc "Qs::RedisConnection"
+    setup do
+      @hella_redis_conn = Factory.string
+      Assert.stub(HellaRedis::RedisConnection, :new) do |config|
+        @config = config
+        @hella_redis_conn
+      end
+
+      @options = {
+        :url      => Factory.url,
+        :redis_ns => Factory.string,
+        :driver   => Factory.string,
+        :timeout  => Factory.integer,
+        :size     => Factory.integer
+      }
+      @redis_connection = Qs::RedisConnection.new(@options)
+    end
+    subject{ @redis_connection }
+
+    should "build a hella redis connection" do
+      assert_instance_of Config, @config
+      assert_equal @options[:url], @config.url
+      assert_equal @options[:redis_ns], @config.redis_ns
+      assert_equal @options[:driver], @config.driver
+      assert_equal @options[:timeout], @config.timeout
+      assert_equal @options[:size], @config.size
+      assert_equal @hella_redis_conn, subject
+    end
+
+  end
+
+end


### PR DESCRIPTION
This adds configuring redis for all of Qs and also adds a utility
for building a redis connection. Qs will build a redis connection
when init which it will use to add jobs and publish events. Daemons
will also build redis connections for pulling jobs off of a queue.
Daemons will also use the global Qs redis configuration for
building their connection.

@kellyredding - Ready for review.
