### PR TITLE
Add `JobHandler` mixin

### DIFF
--- a/lib/qs/job_handler.rb
+++ b/lib/qs/job_handler.rb
@@ -1,0 +1,85 @@
+module Qs
+
+  module JobHandler
+
+    def self.included(klass)
+      klass.class_eval do
+        extend ClassMethods
+        include InstanceMethods
+      end
+    end
+
+    module InstanceMethods
+
+      def initialize(runner)
+        @qs_runner = runner
+      end
+
+      def init
+        run_callback 'before_init'
+        self.init!
+        run_callback 'after_init'
+      end
+
+      def init!
+      end
+
+      def run
+        run_callback 'before_run'
+        self.run!
+        run_callback 'after_run'
+      end
+
+      def run!
+        raise NotImplementedError
+      end
+
+      def inspect
+        reference = '0x0%x' % (self.object_id << 1)
+        "#<#{self.class}:#{reference} @job=#{job.inspect}>"
+      end
+
+      private
+
+      # Helpers
+
+      def job;    @qs_runner.job;    end
+      def params; @qs_runner.params; end
+      def logger; @qs_runner.logger; end
+
+      def run_callback(callback)
+        (self.class.send("#{callback}_callbacks") || []).each do |callback|
+          self.instance_eval(&callback)
+        end
+      end
+
+    end
+
+    module ClassMethods
+
+      def before_callbacks;      @before_callbacks      ||= []; end
+      def after_callbacks;       @after_callbacks       ||= []; end
+      def before_init_callbacks; @before_init_callbacks ||= []; end
+      def after_init_callbacks;  @after_init_callbacks  ||= []; end
+      def before_run_callbacks;  @before_run_callbacks  ||= []; end
+      def after_run_callbacks;   @after_run_callbacks   ||= []; end
+
+      def before(&block);      self.before_callbacks      << block; end
+      def after(&block);       self.after_callbacks       << block; end
+      def before_init(&block); self.before_init_callbacks << block; end
+      def after_init(&block);  self.after_init_callbacks  << block; end
+      def before_run(&block);  self.before_run_callbacks  << block; end
+      def after_run(&block);   self.after_run_callbacks   << block; end
+
+      def prepend_before(&block);      self.before_callbacks.unshift(block);      end
+      def prepend_after(&block);       self.after_callbacks.unshift(block);       end
+      def prepend_before_init(&block); self.before_init_callbacks.unshift(block); end
+      def prepend_after_init(&block);  self.after_init_callbacks.unshift(block);  end
+      def prepend_before_run(&block);  self.before_run_callbacks.unshift(block);  end
+      def prepend_after_run(&block);   self.after_run_callbacks.unshift(block);   end
+
+    end
+
+  end
+
+end

--- a/test/unit/job_handler_tests.rb
+++ b/test/unit/job_handler_tests.rb
@@ -1,0 +1,239 @@
+require 'assert'
+require 'qs/job_handler'
+
+module Qs::JobHandler
+
+  class UnitTests < Assert::Context
+    desc "Qs::JobHandler"
+    setup do
+      @handler_class = Class.new{ include Qs::JobHandler }
+    end
+    subject{ @handler_class }
+
+    should have_imeths :before_callbacks, :after_callbacks
+    should have_imeths :before_init_callbacks, :after_init_callbacks
+    should have_imeths :before_run_callbacks,  :after_run_callbacks
+    should have_imeths :before, :after
+    should have_imeths :before_init, :after_init
+    should have_imeths :before_run,  :after_run
+    should have_imeths :prepend_before, :prepend_after
+    should have_imeths :prepend_before_init, :prepend_after_init
+    should have_imeths :prepend_before_run,  :prepend_after_run
+
+    should "return an empty array by default using `before_callbacks`" do
+      assert_equal [], subject.before_callbacks
+    end
+
+    should "return an empty array by default using `after_callbacks`" do
+      assert_equal [], subject.after_callbacks
+    end
+
+    should "return an empty array by default using `before_init_callbacks`" do
+      assert_equal [], subject.before_init_callbacks
+    end
+
+    should "return an empty array by default using `after_init_callbacks`" do
+      assert_equal [], subject.after_init_callbacks
+    end
+
+    should "return an empty array by default using `before_run_callbacks`" do
+      assert_equal [], subject.before_run_callbacks
+    end
+
+    should "return an empty array by default using `after_run_callbacks`" do
+      assert_equal [], subject.after_run_callbacks
+    end
+
+    should "append a block to the before callbacks using `before`" do
+      subject.before_callbacks << proc{ Factory.string }
+      block = Proc.new{ Factory.string }
+      subject.before(&block)
+      assert_equal block, subject.before_callbacks.last
+    end
+
+    should "append a block to the after callbacks using `after`" do
+      subject.after_callbacks << proc{ Factory.string }
+      block = Proc.new{ Factory.string }
+      subject.after(&block)
+      assert_equal block, subject.after_callbacks.last
+    end
+
+    should "append a block to the before init callbacks using `before_init`" do
+      subject.before_init_callbacks << proc{ Factory.string }
+      block = Proc.new{ Factory.string }
+      subject.before_init(&block)
+      assert_equal block, subject.before_init_callbacks.last
+    end
+
+    should "append a block to the after init callbacks using `after_init`" do
+      subject.after_init_callbacks << proc{ Factory.string }
+      block = Proc.new{ Factory.string }
+      subject.after_init(&block)
+      assert_equal block, subject.after_init_callbacks.last
+    end
+
+    should "append a block to the before run callbacks using `before_run`" do
+      subject.before_run_callbacks << proc{ Factory.string }
+      block = Proc.new{ Factory.string }
+      subject.before_run(&block)
+      assert_equal block, subject.before_run_callbacks.last
+    end
+
+    should "append a block to the after run callbacks using `after_run`" do
+      subject.after_run_callbacks << proc{ Factory.string }
+      block = Proc.new{ Factory.string }
+      subject.after_run(&block)
+      assert_equal block, subject.after_run_callbacks.last
+    end
+
+    should "prepend a block to the before callbacks using `prepend_before`" do
+      subject.before_callbacks << proc{ Factory.string }
+      block = Proc.new{ Factory.string }
+      subject.prepend_before(&block)
+      assert_equal block, subject.before_callbacks.first
+    end
+
+    should "prepend a block to the after callbacks using `prepend_after`" do
+      subject.after_callbacks << proc{ Factory.string }
+      block = Proc.new{ Factory.string }
+      subject.prepend_after(&block)
+      assert_equal block, subject.after_callbacks.first
+    end
+
+    should "prepend a block to the before init callbacks using `prepend_before_init`" do
+      subject.before_init_callbacks << proc{ Factory.string }
+      block = Proc.new{ Factory.string }
+      subject.prepend_before_init(&block)
+      assert_equal block, subject.before_init_callbacks.first
+    end
+
+    should "prepend a block to the after init callbacks using `prepend_after_init`" do
+      subject.after_init_callbacks << proc{ Factory.string }
+      block = Proc.new{ Factory.string }
+      subject.prepend_after_init(&block)
+      assert_equal block, subject.after_init_callbacks.first
+    end
+
+    should "prepend a block to the before run callbacks using `prepend_before_run`" do
+      subject.before_run_callbacks << proc{ Factory.string }
+      block = Proc.new{ Factory.string }
+      subject.prepend_before_run(&block)
+      assert_equal block, subject.before_run_callbacks.first
+    end
+
+    should "prepend a block to the after run callbacks using `prepend_after_run`" do
+      subject.after_run_callbacks << proc{ Factory.string }
+      block = Proc.new{ Factory.string }
+      subject.prepend_after_run(&block)
+      assert_equal block, subject.after_run_callbacks.first
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @runner = FakeRunner.new
+      @handler = TestJobHandler.new(@runner)
+    end
+    subject{ @handler }
+
+    should have_imeths :init, :init!, :run, :run!
+
+    should "know its job, params and logger" do
+      assert_equal @runner.job,    subject.public_job
+      assert_equal @runner.params, subject.public_params
+      assert_equal @runner.logger, subject.public_logger
+    end
+
+    should "call `init!` and its before/after init callbacks using `init`" do
+      subject.init
+      assert_equal 1, subject.first_before_init_call_order
+      assert_equal 2, subject.second_before_init_call_order
+      assert_equal 3, subject.init_call_order
+      assert_equal 4, subject.first_after_init_call_order
+      assert_equal 5, subject.second_after_init_call_order
+    end
+
+    should "call `run!` and its before/after run callbacks using `run`" do
+      subject.run
+      assert_equal 1, subject.first_before_run_call_order
+      assert_equal 2, subject.second_before_run_call_order
+      assert_equal 3, subject.run_call_order
+      assert_equal 4, subject.first_after_run_call_order
+      assert_equal 5, subject.second_after_run_call_order
+    end
+
+    should "have a custom inspect" do
+      reference = '0x0%x' % (subject.object_id << 1)
+      expected = "#<#{subject.class}:#{reference} " \
+                 "@job=#{@runner.job.inspect}>"
+      assert_equal expected, subject.inspect
+    end
+
+    should "raise a not implemented error when `run!` by default" do
+      assert_raises(NotImplementedError){ @handler_class.new(@runner).run! }
+    end
+
+  end
+
+  class TestJobHandler
+    include Qs::JobHandler
+
+    attr_reader :first_before_init_call_order, :second_before_init_call_order
+    attr_reader :first_after_init_call_order, :second_after_init_call_order
+    attr_reader :first_before_run_call_order, :second_before_run_call_order
+    attr_reader :first_after_run_call_order, :second_after_run_call_order
+    attr_reader :init_call_order, :run_call_order
+
+    before_init{ @first_before_init_call_order = next_call_order }
+    before_init{ @second_before_init_call_order = next_call_order }
+
+    after_init{ @first_after_init_call_order = next_call_order }
+    after_init{ @second_after_init_call_order = next_call_order }
+
+    before_run{ @first_before_run_call_order = next_call_order }
+    before_run{ @second_before_run_call_order = next_call_order }
+
+    after_run{ @first_after_run_call_order = next_call_order }
+    after_run{ @second_after_run_call_order = next_call_order }
+
+    def init!
+      @init_call_order = next_call_order
+    end
+
+    def run!
+      @run_call_order = next_call_order
+    end
+
+    def public_job
+      job
+    end
+
+    def public_params
+      params
+    end
+
+    def public_logger
+      logger
+    end
+
+    private
+
+    def next_call_order
+      @order ||= 0
+      @order += 1
+    end
+  end
+
+  class FakeRunner
+    attr_accessor :job, :params, :logger
+
+    def initialize
+      @job = Factory.string
+      @params = Factory.string
+      @logger = Factory.string
+    end
+  end
+
+end


### PR DESCRIPTION
This adds a `JobHandler` mixin that implements our handler pattern
for Qs jobs. This will allow defining handler classes for
processing background jobs.

@kellyredding - Ready for review.
