### PR TITLE
Add runners for live and test environments

### DIFF
--- a/lib/qs/qs_runner.rb
+++ b/lib/qs/qs_runner.rb
@@ -1,0 +1,22 @@
+require 'qs/runner'
+
+module Qs
+
+  class QsRunner < Runner
+
+    def run
+      run_callbacks self.handler_class.before_callbacks
+      self.handler.init
+      self.handler.run
+      run_callbacks self.handler_class.after_callbacks
+    end
+
+    private
+
+    def run_callbacks(callbacks)
+      callbacks.each{ |proc| self.handler.instance_eval(&proc) }
+    end
+
+  end
+
+end

--- a/lib/qs/runner.rb
+++ b/lib/qs/runner.rb
@@ -1,16 +1,24 @@
+require 'qs/logger'
+
 module Qs
 
   class Runner
 
-    def self.run(handler_class, job, logger)
-      self.new(handler_class, job, logger).run
+    attr_reader :handler_class, :handler
+    attr_reader :job, :params, :logger
+
+    def initialize(handler_class, args = nil)
+      @handler_class = handler_class
+      @handler = @handler_class.new(self)
+
+      a = args || {}
+      @job    = a[:job]
+      @params = a[:params] || {}
+      @logger = a[:logger] || Qs::NullLogger.new
     end
 
-    def initialize(handler_class, job, logger = nil)
-      # TODO
-      @handler_class = handler_class
-      @job           = job
-      @logger        = logger
+    def run
+      raise NotImplementedError
     end
 
   end

--- a/lib/qs/test_runner.rb
+++ b/lib/qs/test_runner.rb
@@ -1,0 +1,32 @@
+require 'qs/job_handler'
+require 'qs/runner'
+
+module Qs
+
+  InvalidJobHandlerError = Class.new(StandardError)
+
+  class TestRunner < Runner
+
+    def initialize(handler_class, args = nil)
+      if !handler_class.include?(Qs::JobHandler)
+        raise InvalidJobHandlerError, "#{handler_class.inspect} is not a"\
+                                      " Qs::JobHandler"
+      end
+      args = (args || {}).dup
+      super(handler_class, {
+        :job    => args.delete(:job),
+        :params => args.delete(:params),
+        :logger => args.delete(:logger)
+      })
+      args.each{ |key, value| self.handler.send("#{key}=", value) }
+
+      self.handler.init
+    end
+
+    def run
+      self.handler.run
+    end
+
+  end
+
+end

--- a/test/unit/qs_runner_tests.rb
+++ b/test/unit/qs_runner_tests.rb
@@ -1,0 +1,87 @@
+require 'assert'
+require 'qs/qs_runner'
+
+require 'qs/job_handler'
+
+class Qs::QsRunner
+
+  class UnitTests < Assert::Context
+    desc "Qs::QsRunner"
+    setup do
+      @runner_class = Qs::QsRunner
+    end
+    subject{ @runner_class }
+
+    should "be a runner" do
+      assert_true subject < Qs::Runner
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @handler_class = TestJobHandler
+      @runner = @runner_class.new(@handler_class)
+    end
+    subject{ @runner }
+
+    should have_imeths :run
+
+  end
+
+  class RunTests < InitTests
+    desc "and run"
+    setup do
+      @handler = @runner.handler
+      @runner.run
+    end
+
+    should "run the handlers before callbacks" do
+      assert_equal 1, @handler.first_before_call_order
+      assert_equal 2, @handler.second_before_call_order
+    end
+
+    should "call the handlers init and run methods" do
+      assert_equal 3, @handler.init_call_order
+      assert_equal 4, @handler.run_call_order
+    end
+
+    should "run the handlers after callbacks" do
+      assert_equal 5, @handler.first_after_call_order
+      assert_equal 6, @handler.second_after_call_order
+    end
+
+  end
+
+  class TestJobHandler
+    include Qs::JobHandler
+
+    attr_reader :first_before_call_order, :second_before_call_order
+    attr_reader :first_after_call_order, :second_after_call_order
+    attr_reader :init_call_order, :run_call_order
+    attr_reader :response_data
+
+    before{ @first_before_call_order = next_call_order }
+    before{ @second_before_call_order = next_call_order }
+
+    after{ @first_after_call_order = next_call_order }
+    after{ @second_after_call_order = next_call_order }
+
+    def init!
+      @init_call_order = next_call_order
+    end
+
+    def run!
+      @run_call_order = next_call_order
+    end
+
+    private
+
+    def next_call_order
+      @order ||= 0
+      @order += 1
+    end
+  end
+
+end

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -1,0 +1,63 @@
+require 'assert'
+require 'qs/runner'
+
+require 'qs/job_handler'
+require 'qs/logger'
+
+class Qs::Runner
+
+  class UnitTests < Assert::Context
+    desc "Qs::Runner"
+    setup do
+      @runner_class = Qs::Runner
+    end
+    subject{ @runner_class }
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @handler_class = TestJobHandler
+      @runner = @runner_class.new(@handler_class)
+    end
+    subject{ @runner }
+
+    should have_readers :handler_class, :handler
+    should have_readers :job, :params, :logger
+    should have_imeths :run
+
+    should "know its handler class and handler" do
+      assert_equal @handler_class, subject.handler_class
+      assert_instance_of @handler_class, subject.handler
+    end
+
+    should "not set its job, params or logger by default" do
+      assert_nil subject.job
+      assert_equal({}, subject.params)
+      assert_instance_of Qs::NullLogger, subject.logger
+    end
+
+    should "allow passing a job, params and logger" do
+      args = {
+        :job    => Factory.string,
+        :params => Factory.string,
+        :logger => Factory.string
+      }
+      runner = @runner_class.new(@handler_class, args)
+      assert_equal args[:job],    runner.job
+      assert_equal args[:params], runner.params
+      assert_equal args[:logger], runner.logger
+    end
+
+    should "raise a not implemented error when run" do
+      assert_raises(NotImplementedError){ subject.run }
+    end
+
+  end
+
+  class TestJobHandler
+    include Qs::JobHandler
+  end
+
+end

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -1,0 +1,108 @@
+require 'assert'
+require 'qs/test_runner'
+
+class Qs::TestRunner
+
+  class UnitTests < Assert::Context
+    desc "Qs::TestRunner"
+    setup do
+      @runner_class = Qs::TestRunner
+    end
+    subject{ @runner_class }
+
+    should "be a runner" do
+      assert_true subject < Qs::Runner
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @handler_class = TestJobHandler
+      @args = {
+        :job    => Factory.string,
+        :params => { Factory.string => Factory.string },
+        :logger => Factory.string,
+        :flag   => Factory.boolean
+      }
+      @original_args = @args.dup
+      @runner = @runner_class.new(@handler_class, @args)
+      @handler = @runner.handler
+    end
+    subject{ @runner }
+
+    should have_imeths :run
+
+    should "know its job, params and logger" do
+      assert_equal @args[:job], subject.job
+      assert_equal @args[:params], subject.params
+      assert_equal @args[:logger], subject.logger
+    end
+
+    should "write extra args to its job handler" do
+      assert_equal @args[:flag], @handler.flag
+    end
+
+    should "not alter the args passed to it" do
+      assert_equal @original_args, @args
+    end
+
+    should "not call its job handler's before callbacks" do
+      assert_nil @handler.before_called
+    end
+
+    should "call its job handler's init" do
+      assert_true @handler.init_called
+    end
+
+    should "not run its job handler" do
+      assert_nil @handler.run_called
+    end
+
+    should "not call its job handler's after callbacks" do
+      assert_nil @handler.after_called
+    end
+
+    should "raise an invalid error when not passed a job handler" do
+      assert_raises(Qs::InvalidJobHandlerError){ @runner_class.new(Class.new) }
+    end
+
+  end
+
+  class RunTests < InitTests
+    desc "and run"
+    setup do
+      @runner.run
+    end
+
+    should "run its job handler" do
+      assert_true @handler.run_called
+    end
+
+    should "not call its job handler's after callbacks" do
+      assert_nil @handler.after_called
+    end
+
+  end
+
+  class TestJobHandler
+    include Qs::JobHandler
+
+    attr_reader :before_called, :after_called
+    attr_reader :init_called, :run_called
+    attr_accessor :flag
+
+    before{ @before_called = true }
+    after{ @after_called = true }
+
+    def init!
+      @init_called = true
+    end
+
+    def run!
+      @run_called = true
+    end
+  end
+
+end


### PR DESCRIPTION
This adds a `Runner`, `QsRunner` and `TestRunner`. This provides
a live runner, a test runner and the common logic between them.
The runner, in both live and test environments, is responsible
for building a handler class and running it appropriately. This
is part of working with the handler pattern and allows also
unit testing handlers without having to know Qs implementation
details.

@kellyredding - Ready for review.
