### PR TITLE
Add `Job`, handles converting to/from payloads

### DIFF
--- a/lib/qs/job.rb
+++ b/lib/qs/job.rb
@@ -2,19 +2,67 @@ module Qs
 
   class Job
 
-    def self.parse(job_string)
-      self.new({}) # TODO
+    def self.parse(payload)
+      created_at = Time.at(payload['created_at'].to_i)
+      self.new(payload['name'], payload['params'], created_at)
     end
 
-    attr_reader :name, :type, :params
+    attr_reader :name, :params, :created_at
 
-    def initialize(job_hash)
-      # TODO
-      @name   = 'test_job'
-      @type   = 'job'
-      @params = { 'some' => 'param' }
+    def initialize(name, params, created_at = nil)
+      validate!(name, params)
+      @name       = name
+      @params     = params
+      @created_at = created_at || Time.now
+    end
+
+    def to_payload
+      { 'name'       => self.name,
+        'params'     => stringify(self.params),
+        'created_at' => self.created_at.to_i
+      }
+    end
+
+    def inspect
+      reference = '0x0%x' % (self.object_id << 1)
+      "#<#{self.class}:#{reference} " \
+      "@name=#{self.name.inspect} " \
+      "@params=#{self.params.inspect} " \
+      "@created_at=#{self.created_at.inspect}>"
+    end
+
+    def ==(other)
+      if other.kind_of?(self.class)
+        self.to_payload == other.to_payload
+      else
+        super
+      end
+    end
+
+    private
+
+    def validate!(name, params)
+      problem = if name.to_s.empty?
+        "The job doesn't have a name."
+      elsif !params.kind_of?(::Hash)
+        "The job's params are not valid."
+      end
+      raise(BadJobError, problem) if problem
+    end
+
+    def stringify(object)
+      case(object)
+      when Hash
+        object.inject({}){ |h, (k, v)| h.merge(k.to_s => stringify(v)) }
+      when Array
+        object.map{ |item| stringify(item) }
+      else
+        object
+      end
     end
 
   end
+
+  BadJobError = Class.new(ArgumentError)
 
 end

--- a/test/unit/job_tests.rb
+++ b/test/unit/job_tests.rb
@@ -1,0 +1,111 @@
+require 'assert'
+require 'qs/job'
+
+class Qs::Job
+
+  class UnitTests < Assert::Context
+    desc "Qs::Job"
+    setup do
+      @job_class = Qs::Job
+    end
+    subject{ @job_class }
+
+    should have_imeths :parse
+
+    should "parse a job from a payload hash" do
+      payload = {
+        'name'     => Factory.string,
+        'params'   => { Factory.string => Factory.string },
+        'created_at' => Factory.time.to_i
+      }
+      job = subject.parse(payload)
+      assert_instance_of subject, job
+      assert_equal payload['name'], job.name
+      assert_equal payload['params'], job.params
+      assert_equal Time.at(payload['created_at']), job.created_at
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @current_time = Factory.time
+      Assert.stub(Time, :now).with{ @current_time }
+
+      @name     = Factory.string
+      @params   = { Factory.string => Factory.string }
+      @created_at = Factory.time
+      @job = @job_class.new(@name, @params, @created_at)
+    end
+    subject{ @job }
+
+    should have_readers :name, :params, :created_at
+    should have_imeths :to_payload
+
+    should "know its name, params and added at" do
+      assert_equal @name,     subject.name
+      assert_equal @params,   subject.params
+      assert_equal @created_at, subject.created_at
+    end
+
+    should "default its added at" do
+      job = @job_class.new(@name, @params)
+      assert_equal @current_time, job.created_at
+    end
+
+    should "return a payload hash using `to_payload`" do
+      payload_hash = subject.to_payload
+      expected = {
+        'name'     => @name,
+        'params'   => @params,
+        'created_at' => @created_at.to_i
+      }
+      assert_equal expected, payload_hash
+    end
+
+    should "convert params keys to strings using `to_payload`" do
+      params = {
+        :basic    => Factory.string,
+        :in_array => [ { :test => Factory.string } ],
+        :nested   => { :test => Factory.string }
+      }
+      job = @job_class.new(@name, params)
+      expected = {
+        'basic'    => params[:basic],
+        'in_array' => [ { 'test' => params[:in_array].first[:test] } ],
+        'nested'   => { 'test' => params[:nested][:test] }
+      }
+      assert_equal expected, job.to_payload['params']
+    end
+
+    should "raise an error when given an invalid name or params" do
+      assert_raises(Qs::BadJobError){ @job_class.new(nil, @params) }
+      assert_raises(Qs::BadJobError){ @job_class.new(@name, nil) }
+      assert_raises(Qs::BadJobError){ @job_class.new(@name, Factory.string) }
+    end
+
+    should "have a custom inspect" do
+      reference = '0x0%x' % (subject.object_id << 1)
+      expected = "#<Qs::Job:#{reference} " \
+                 "@name=#{subject.name.inspect} " \
+                 "@params=#{subject.params.inspect} " \
+                 "@created_at=#{subject.created_at.inspect}>"
+      assert_equal expected, subject.inspect
+    end
+
+    should "be comparable" do
+      matching = @job_class.new(@name, @params, @created_at)
+      assert_equal matching, subject
+      non_matching = @job_class.new(Factory.string, @params, @created_at)
+      assert_not_equal non_matching, subject
+      params = { Factory.string => Factory.string }
+      non_matching = @job_class.new(@name, params, @created_at)
+      assert_not_equal non_matching, subject
+      non_matching = @job_class.new(@name, @params, Factory.time)
+      assert_not_equal non_matching, subject
+    end
+
+  end
+
+end


### PR DESCRIPTION
This adds a `Job` class that handles converting a name and params
to and from a payload hash. This will be built when adding a job to
a queue and will be used to parse a payload pulled out of redis.
The `Job` instance is passed down to the handler for use in
handling the background job. A `Job` also includes a `created_at`
that references the time it was added to a queue. This can be
used to detect when an action occurred as opposed to when the
background worker decided to finally handle the job.

@kellyredding - Ready for review.
