### PR TITLE
Update `ErrorHandler`, match Sanford error handler

### DIFF
--- a/lib/qs/error_handler.rb
+++ b/lib/qs/error_handler.rb
@@ -2,23 +2,28 @@ module Qs
 
   class ErrorHandler
 
-    def initialize(queue, error_procs)
-      @error_procs = [*error_procs].compact
-      @queue       = queue
+    attr_reader :exception, :daemon_data, :job
+    attr_reader :error_procs
+
+    def initialize(exception, daemon_data, job = nil)
+      @exception, @daemon_data, @job = exception, daemon_data, job
+      @error_procs = @daemon_data.error_procs.reverse
     end
 
-    # If an error is raised from an error proc, it will be passed to the next
-    # error proc. This is designed to avoid "hidden" errors happening, this way
-    # the daemon will log based on the last exception that occurred.
-    def run(exception, job = nil)
+    # The exception that we are handling can change in the case that the
+    # configured error proc raises an exception. If this occurs, the new
+    # exception will be passed to subsequent error procs. This is designed to
+    # avoid "hidden" errors, this way the daemon will log based on the last
+    # exception that occurred.
+
+    def run
       @error_procs.each do |error_proc|
         begin
-          error_proc.call(exception, @queue, job)
-        rescue Exception => proc_exception
-          exception = proc_exception
+          error_proc.call(@exception, @daemon_data, @job)
+        rescue StandardError => proc_exception
+          @exception = proc_exception
         end
       end
-      exception
     end
 
   end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -3,4 +3,12 @@ require 'assert/factory'
 module Factory
   extend Assert::Factory
 
+  def self.exception(klass = nil, message = nil)
+    klass ||= StandardError
+    message ||= Factory.text
+    exception = nil
+    begin; raise(klass, message); rescue StandardError => exception; end
+    exception
+  end
+
 end


### PR DESCRIPTION
This updates the `ErrorHandler` to behave similar to Sanford's
error handler. It takes an exception, a daemon data and an
optional job. This is because the error handler is called if any
exception occurs while handling a payload and a job may not have
been parsed when the exception occurs. The daemon data's error
procs are called and passed the exception, daemon data and job.
If an error proc raises an exception, the new exception will be
passed to any subsequent error procs and the last exception that
is thrown will be logged by the daemon. This is to avoid any
errors being "hidden" and behaves the same as a bunch of nested
begin-rescue-end statements.

@kellyredding - Ready for review.
