### PR TITLE
Implement `Route#run`

### DIFF
--- a/lib/qs/route.rb
+++ b/lib/qs/route.rb
@@ -1,3 +1,5 @@
+require 'qs/qs_runner'
+
 module Qs
 
   class Route
@@ -14,8 +16,12 @@ module Qs
       @handler_class = constantize_handler_class(@handler_class_name)
     end
 
-    def run
-      # TODO
+    def run(job, daemon_data)
+      QsRunner.new(self.handler_class, {
+        :job    => job,
+        :params => job.params,
+        :logger => daemon_data.logger
+      }).run
     end
 
     private


### PR DESCRIPTION
This adds the logic for running a route. It will build and run a
`QsRunner`, passing the job, the job params and the daemon data's
logger to it. The route was implemented before the runner or job
so it was left as a todo. This is needed to run a job handler when
a job is pulled off of a queue.

@kellyredding - Ready for review.
