### PR TITLE
Update `Daemon` with start, stop and halt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ gemspec
 
 gem 'rake'
 gem 'pry', "~> 0.9.0"
+
+gem 'dat-worker-pool', :path => "~/Projects/redding/gems/dat-worker-pool"

--- a/lib/qs/daemon.rb
+++ b/lib/qs/daemon.rb
@@ -1,10 +1,16 @@
 require 'ns-options'
 require 'pathname'
+require 'system_timer'
+require 'thread'
+require 'qs/daemon_data'
 require 'qs/logger'
+require 'qs/payload_handler'
 
 module Qs
 
   module Daemon
+
+    InvalidError = Class.new(ArgumentError)
 
     def self.included(klass)
       klass.class_eval do
@@ -14,6 +20,102 @@ module Qs
     end
 
     module InstanceMethods
+
+      attr_reader :daemon_data, :logger
+
+      def initialize
+        self.class.configuration.validate!
+        @daemon_data = DaemonData.new(self.class.configuration.to_hash)
+        @logger = @daemon_data.logger
+
+        @work_loop_thread = nil
+        @worker_pool      = nil
+
+        @signal = Signal.new(:stop)
+      rescue InvalidError => exception
+        exception.set_backtrace(caller)
+        raise exception
+      end
+
+      def running?
+        !!(@work_loop_thread && @work_loop_thread.alive?)
+      end
+
+      def start
+        @signal.set :start
+        @work_loop_thread ||= Thread.new{ work_loop }
+      end
+
+      def stop(wait = false)
+        return unless self.running?
+        @signal.set :stop
+        wait_for_shutdown if wait
+      end
+
+      def halt(wait = false)
+        return unless self.running?
+        @signal.set :halt
+        wait_for_shutdown if wait
+      end
+
+      private
+
+      def process(serialized_payload)
+        # TODO
+      end
+
+      def work_loop
+        self.logger.debug "Starting work loop..."
+        @worker_pool = DatWorkerPool.new(
+          self.daemon_data.min_workers,
+          self.daemon_data.max_workers
+        ){ |serialized_payload| process(serialized_payload) }
+        process_inputs while @signal.start?
+        self.logger.debug "Stopping work loop..."
+        shutdown_worker_pool unless @signal.halt?
+      rescue StandardError => exception
+        self.logger.error "Exception occurred, stopping daemon!"
+        self.logger.error "#{exception.class}: #{exception.message}"
+        self.logger.error exception.backtrace.join("\n")
+      ensure
+        @work_loop_thread = nil
+        self.logger.debug "Stopped work loop"
+      end
+
+      def process_inputs
+        sleep 1 # TODO
+      end
+
+      def shutdown_worker_pool
+        self.logger.debug "Shutting down worker pool, letting it finish..."
+        if self.daemon_data.shutdown_timeout
+          shutdown_worker_pool_with_timeout(self.daemon_data.shutdown_timeout)
+        else
+          shutdown_worker_pool_without_timeout
+        end
+      end
+
+      def shutdown_worker_pool_with_timeout(timeout)
+        SystemTimer.timeout_after(timeout) do
+          wait_for_worker_pool_to_empty
+          @worker_pool.shutdown(timeout)
+        end
+      rescue Timeout::Error
+        @worker_pool.shutdown(0)
+      end
+
+      def shutdown_worker_pool_without_timeout
+        wait_for_worker_pool_to_empty
+        @worker_pool.shutdown
+      end
+
+      def wait_for_worker_pool_to_empty
+        sleep(5) while !@worker_pool.queue_empty? && !@signal.halt?
+      end
+
+      def wait_for_shutdown
+        @work_loop_thread.join if @work_loop_thread
+      end
 
     end
 
@@ -121,7 +223,28 @@ module Qs
       end
     end
 
-    InvalidError = Class.new(RuntimeError)
+    class Signal
+      def initialize(value)
+        @value = value
+        @mutex = Mutex.new
+      end
+
+      def set(value)
+        @mutex.synchronize{ @value = value }
+      end
+
+      def start?
+        @mutex.synchronize{ @value == :start }
+      end
+
+      def stop?
+        @mutex.synchronize{ @value == :stop }
+      end
+
+      def halt?
+        @mutex.synchronize{ @value == :halt }
+      end
+    end
 
   end
 

--- a/qs.gemspec
+++ b/qs.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency("hella-redis",     ["~> 0.1"])
   gem.add_dependency("ns-options",      ["~> 1.1"])
   gem.add_dependency("oj",              ["~> 2.11"])
+  gem.add_dependency("SystemTimer",     ["~> 1.2"])
 
   gem.add_development_dependency("assert", ["~> 2.12"])
 end


### PR DESCRIPTION
This updates the `Daemon` with its start, stop and halt behavior.
When started, it will now build a `DatWorkerPool` that will be
responsible for handing work off to multiple threads. When stopped
the daemon will shutdown the worker pool using its configured
timeout. This will allow a `Qs::Process` to control a daemon. This
doesn't include the logic for pulling jobs out of redis and adding
them to the worker pool, it is just the start, stop and halt
behavior.

@kellyredding - Ready for review.
