### PR TITLE
Add `enqueue` to `Qs` and `add` to `Queue`

### DIFF
--- a/lib/qs.rb
+++ b/lib/qs.rb
@@ -1,6 +1,9 @@
 require 'hella-redis'
 require 'ns-options'
 require 'qs/version'
+require 'qs/job'
+require 'qs/payload'
+require 'qs/queue'
 
 module Qs
 
@@ -16,6 +19,13 @@ module Qs
       self.config.redis.db
     )
     @redis = HellaRedis::Connection.new(self.redis_config)
+  end
+
+  def self.enqueue(queue, job_name, params = nil)
+    job = Qs::Job.new(job_name, params || {})
+    encoded_payload = Qs::Payload.encode(job.to_payload)
+    self.redis.with{ |c| c.lpush(queue.redis_key, encoded_payload) }
+    job
   end
 
   def self.redis

--- a/lib/qs/queue.rb
+++ b/lib/qs/queue.rb
@@ -19,7 +19,7 @@ module Qs
     end
 
     def redis_key
-      "queues:#{@name}"
+      @redis_key ||= "queues:#{name}"
     end
 
     def job_handler_ns(value = nil)
@@ -33,6 +33,10 @@ module Qs
       end
 
       @routes.push(Qs::Route.new(name, handler_name))
+    end
+
+    def add(job_name, params = nil)
+      Qs.enqueue(self, job_name, params)
     end
 
     def inspect


### PR DESCRIPTION
This adds an `enqueue` method to `Qs` and `add` to `Queue`. These
allow adding jobs to queues in redis to be processed by daemons.
The `enqueue` method on `Qs` takes a queue name, a job name and
job params. The `add` method on `Queue` only takes a job name and
job params. This allows multiple convenient methods to add jobs
to a queue to be processed.

@kellyredding - Ready for review.