### PR TITLE
Add system tests for `Daemon`

### DIFF
--- a/lib/qs.rb
+++ b/lib/qs.rb
@@ -2,6 +2,7 @@ require 'hella-redis'
 require 'ns-options'
 require 'qs/version'
 require 'qs/job'
+require 'qs/job_handler'
 require 'qs/payload'
 require 'qs/queue'
 

--- a/test/support/app_daemon.rb
+++ b/test/support/app_daemon.rb
@@ -2,11 +2,48 @@ require 'qs'
 
 AppQueue = Qs::Queue.new do
   name 'app_main'
+
+  job_handler_ns 'AppHandlers'
+
+  job 'basic', 'Basic'
+  job 'error', 'Error'
 end
 
 class AppDaemon
   include Qs::Daemon
 
   name 'app'
+
+  logger Logger.new(ROOT_PATH.join('log/app_daemon.log').to_s)
+  verbose_logging true
+
   queue AppQueue
+
+  error do |exception, daemon_data, job|
+    if job && job.name == 'error'
+      message = "#{exception.class}: #{exception.message}"
+      Qs.redis.with{ |c| c.set('last_error', message) }
+    end
+  end
+
+end
+
+module AppHandlers
+
+  class Basic
+    include Qs::JobHandler
+
+    def run!
+      Qs.redis.with{ |c| c.set(params['key'], params['value']) }
+    end
+  end
+
+  class Error
+    include Qs::JobHandler
+
+    def run!
+      raise params['error_message']
+    end
+  end
+
 end

--- a/test/system/daemon_tests.rb
+++ b/test/system/daemon_tests.rb
@@ -1,0 +1,70 @@
+require 'assert'
+require 'qs/daemon'
+
+require 'test/support/app_daemon'
+
+module Qs::Daemon
+
+  class SystemTests < Assert::Context
+    desc "Qs::Daemon"
+    setup do
+      Qs.init
+
+      @daemon = AppDaemon.new
+      @daemon_runner = DaemonRunner.new(@daemon).tap(&:start)
+    end
+    teardown do
+      @daemon_runner.stop
+    end
+
+  end
+
+  class BasicJobTests < SystemTests
+    desc "with a basic job added"
+    setup do
+      @key, @value = [Factory.string, Factory.string]
+      AppQueue.add('basic', {
+        'key'   => @key,
+        'value' => @value
+      })
+    end
+
+    should "run the job" do
+      sleep 0.5
+      assert_equal @value, Qs.redis.with{ |c| c.get(@key) }
+    end
+
+  end
+
+  class JobThatErrorsTests < SystemTests
+    desc "with a job that errors"
+    setup do
+      @error_message = Factory.text
+      AppQueue.add('error', 'error_message' => @error_message)
+    end
+
+    should "run the configured error handler procs" do
+      sleep 0.5
+      exp = "RuntimeError: #{@error_message}"
+      assert_equal exp, Qs.redis.with{ |c| c.get('last_error') }
+    end
+
+  end
+
+  class DaemonRunner
+    def initialize(daemon)
+      @daemon = daemon
+      @thread = nil
+    end
+
+    def start
+      @thread = @daemon.start
+    end
+
+    def stop
+      @daemon.halt
+      @thread.join if @thread
+    end
+  end
+
+end


### PR DESCRIPTION
This adds system tests that test running a `Daemon` in a separate
thread and adding jobs to it. This ensures that from the `Daemon`
to the `JobHandler` jobs are processed correctly. This includes
properly handling exceptions that are raised while processing a
job.

This requires `JobHandler` from `Qs` because it is not being
required via any other `Qs` file.

@kellyredding - Ready for review.