### PR TITLE
Add `TestClient` and test mode, track enqueued jobs in memory

### DIFF
--- a/lib/qs/client.rb
+++ b/lib/qs/client.rb
@@ -1,0 +1,75 @@
+require 'hella-redis'
+require 'qs/job'
+require 'qs/payload'
+
+module Qs
+
+  module Client
+
+    def self.new(redis)
+      if !ENV['QS_TEST_MODE']
+        QsClient.new(redis)
+      else
+        TestClient.new(redis)
+      end
+    end
+
+    def self.included(klass)
+      klass.class_eval do
+        include InstanceMethods
+      end
+    end
+
+    module InstanceMethods
+
+      attr_reader :redis_config, :redis
+
+      def initialize(redis_config)
+        @redis_config = redis_config
+      end
+
+      def enqueue(queue, job_name, params = nil)
+        job = Qs::Job.new(job_name, params || {})
+        enqueue!(queue, job)
+        job
+      end
+
+    end
+
+  end
+
+  class QsClient
+    include Client
+
+    def initialize(*args)
+      super
+      @redis = HellaRedis::Connection.new(self.redis_config)
+    end
+
+    private
+
+    def enqueue!(queue, job)
+      encoded_payload = Qs::Payload.encode(job.to_payload)
+      self.redis.with{ |c| c.lpush(queue.redis_key, encoded_payload) }
+    end
+
+  end
+
+  class TestClient
+    include Client
+
+    def initialize(*args)
+      super
+      require 'hella-redis/connection_spy'
+      @redis = HellaRedis::ConnectionSpy.new(self.redis_config)
+    end
+
+    private
+
+    def enqueue!(queue, job)
+      queue.enqueued_jobs << job
+    end
+
+  end
+
+end

--- a/lib/qs/queue.rb
+++ b/lib/qs/queue.rb
@@ -5,10 +5,12 @@ module Qs
   class Queue
 
     attr_reader :routes
+    attr_reader :enqueued_jobs
 
     def initialize(&block)
       @job_handler_ns = nil
       @routes = []
+      @enqueued_jobs = []
       self.instance_eval(&block) if !block.nil?
       raise InvalidError, "a queue must have a name" if self.name.nil?
     end
@@ -35,8 +37,13 @@ module Qs
       @routes.push(Qs::Route.new(name, handler_name))
     end
 
-    def add(job_name, params = nil)
+    def enqueue(job_name, params = nil)
       Qs.enqueue(self, job_name, params)
+    end
+    alias :add :enqueue
+
+    def reset!
+      self.enqueued_jobs.clear
     end
 
     def inspect

--- a/test/unit/client_tests.rb
+++ b/test/unit/client_tests.rb
@@ -1,0 +1,153 @@
+require 'assert'
+require 'qs/client'
+
+require 'qs/job'
+require 'qs/queue'
+
+module Qs::Client
+
+  class UnitTests < Assert::Context
+    desc "Qs::Client"
+    setup do
+      @current_test_mode = ENV['QS_TEST_MODE']
+      ENV['QS_TEST_MODE'] = 'yes'
+
+      @redis_config = Qs.redis_config
+      @queue = Qs::Queue.new{ name Factory.string }
+      @job   = Qs::Job.new(Factory.string, Factory.string => Factory.string)
+    end
+    teardown do
+      ENV['QS_TEST_MODE'] = @current_test_mode
+    end
+    subject{ Qs::Client }
+
+    should have_imeths :new
+
+    should "return a qs client using `new`" do
+      ENV.delete('QS_TEST_MODE')
+      client = subject.new(@redis_config)
+      assert_instance_of Qs::QsClient, client
+    end
+
+    should "return a test client using `new` in test mode" do
+      client = subject.new(@redis_config)
+      assert_instance_of Qs::TestClient, client
+    end
+
+  end
+
+  class MixinTests < UnitTests
+    setup do
+      @client_class = Class.new do
+        include Qs::Client
+      end
+      @client = @client_class.new(@redis_config)
+    end
+    subject{ @client }
+
+    should have_readers :redis_config, :redis
+    should have_imeths :enqueue
+
+    should "know its redis config" do
+      assert_equal @redis_config, subject.redis_config
+    end
+
+    should "not have a redis connection" do
+      assert_nil subject.redis
+    end
+
+  end
+
+  class QsClientTests < UnitTests
+    desc "QsClient"
+    setup do
+      @client_class = Qs::QsClient
+    end
+    subject{ @client_class }
+
+    should "be a qs client" do
+      assert_includes Qs::Client, subject
+    end
+
+  end
+
+  class QsClientInitTests < QsClientTests
+    desc "when init"
+    setup do
+      @connection_spy = nil
+      Assert.stub(HellaRedis::Connection, :new) do |*args|
+        @connection_spy = HellaRedis::ConnectionSpy.new(*args)
+      end
+
+      @client = @client_class.new(@redis_config)
+    end
+    subject{ @client }
+
+    should "build a redis connection" do
+      assert_not_nil @connection_spy
+      assert_equal @connection_spy.config, subject.redis_config
+      assert_equal @connection_spy, subject.redis
+    end
+
+    should "add jobs to the queue's redis list using `enqueue`" do
+      subject.enqueue(@queue, @job.name, @job.params)
+
+      call = @connection_spy.redis_calls.last
+      assert_equal :lpush, call.command
+      assert_equal @queue.redis_key, call.args.first
+      assert_equal @job.to_payload, Qs::Payload.decode(call.args.last)
+    end
+
+    should "default the job's params to an empty hash using `enqueue`" do
+      subject.enqueue(@queue, @job.name)
+
+      call = @connection_spy.redis_calls.last
+      assert_equal :lpush, call.command
+      exp = @job.to_payload.merge('params' => {})
+      assert_equal exp, Qs::Payload.decode(call.args.last)
+    end
+
+    should "return the job when enqueuing" do
+      result = subject.enqueue(@queue, @job.name, @job.params)
+      assert_equal @job, result
+    end
+
+  end
+
+  class TestClientTests < UnitTests
+    desc "TestClient"
+    setup do
+      @client_class = Qs::TestClient
+    end
+    subject{ @client_class }
+
+    should "be a qs client" do
+      assert_includes Qs::Client, subject
+    end
+
+  end
+
+  class TestClientInitTests < TestClientTests
+    desc "when init"
+    setup do
+      @client = @client_class.new(@redis_config)
+    end
+    subject{ @client }
+
+    should "build a redis connection spy" do
+      assert_instance_of HellaRedis::ConnectionSpy, subject.redis
+      assert_equal @redis_config, subject.redis.config
+    end
+
+    should "track all the jobs it enqueues on the queue" do
+      assert_empty @queue.enqueued_jobs
+      result = subject.enqueue(@queue, @job.name, @job.params)
+
+      job = @queue.enqueued_jobs.last
+      assert_equal @job, job
+      assert_equal @job, result
+    end
+
+  end
+
+end

--- a/test/unit/daemon_tests.rb
+++ b/test/unit/daemon_tests.rb
@@ -259,18 +259,18 @@ module Qs::Daemon
     setup do
       @daemon = @daemon_class.new
       @thread = @daemon.start
+
+      @serialized_payload = Factory.string
+      @connection_spy.add_item_to_list(@queue.redis_key, @serialized_payload)
     end
     subject{ @daemon }
 
     should "call brpop on its redis connection and add work to the worker pool" do
-      serialized_payload = Factory.string
-      @connection_spy.add_item_to_list(@queue.redis_key, serialized_payload)
-
       call = @connection_spy.redis_calls.last
       assert_equal :brpop, call.command
       exp = [subject.signals_redis_key, subject.queue_redis_keys, 0].flatten
       assert_equal exp, call.args
-      assert_equal serialized_payload, @worker_pool_spy.work_items.first
+      assert_equal @serialized_payload, @worker_pool_spy.work_items.first
     end
 
   end


### PR DESCRIPTION
This adds a `TestClient` that is built when Qs is in test mode (set
with an env variable). The test client is a helper for tests that
will track any jobs that are enqueued in memory and allow
inspecting them. The jobs are stored on the queue that they are
enqueued on. This is nice for testing that a job was enqueued
and making sure it was enqueued with the correct params.

This also includes a `reset!` method on the `Qs` module. This
allows undoing its current client and redis connection so `init`
can be called again. This will allow switching between live and
test mode in the same process if desired (like qs own test suite).

This also includes a minor cleanup to the daemon tests that moves
some "setup" logic into the setup block instead of the should
block.

@kellyredding - Ready for review.