### PR TITLE
Add job timeouts

### DIFF
--- a/bench/report.txt
+++ b/bench/report.txt
@@ -5,7 +5,7 @@ Adding jobs
 Running jobs
 ....................................................................................................
 
-Adding 10000 Jobs Time:   1.6565s
-Running 10000 Jobs Time: 12.0629s
+Adding 10000 Jobs Time:   1.6252s
+Running 10000 Jobs Time: 12.4884s
 
 Done running benchmark report

--- a/lib/qs.rb
+++ b/lib/qs.rb
@@ -64,6 +64,8 @@ module Qs
     option :serializer,   Proc, :default => proc{ |p| ::JSON.dump(p) }
     option :deserializer, Proc, :default => proc{ |p| ::JSON.load(p) }
 
+    option :timeout, Float
+
     namespace :redis do
       option :ip,   :default => 'localhost'
       option :port, :default => 6379

--- a/lib/qs/job_handler.rb
+++ b/lib/qs/job_handler.rb
@@ -57,6 +57,11 @@ module Qs
 
     module ClassMethods
 
+      def timeout(value = nil)
+        @timeout = value.to_f if value
+        @timeout
+      end
+
       def before_callbacks;      @before_callbacks      ||= []; end
       def after_callbacks;       @after_callbacks       ||= []; end
       def before_init_callbacks; @before_init_callbacks ||= []; end

--- a/lib/qs/qs_runner.rb
+++ b/lib/qs/qs_runner.rb
@@ -1,14 +1,29 @@
+require 'system_timer'
+require 'qs'
 require 'qs/runner'
 
 module Qs
 
   class QsRunner < Runner
 
+    attr_reader :timeout
+
+    def initialize(handler_class, args = nil)
+      super(handler_class, args)
+      @timeout = handler_class.timeout || Qs.config.timeout
+    end
+
     def run
-      run_callbacks self.handler_class.before_callbacks
-      self.handler.init
-      self.handler.run
-      run_callbacks self.handler_class.after_callbacks
+      OptionalTimeout.new(self.timeout) do
+        run_callbacks self.handler_class.before_callbacks
+        self.handler.init
+        self.handler.run
+        run_callbacks self.handler_class.after_callbacks
+      end
+    rescue TimeoutError => exception
+      error = TimeoutError.new "#{handler_class} timed out (#{timeout}s)"
+      error.set_backtrace(exception.backtrace)
+      raise error
     end
 
     private
@@ -17,6 +32,18 @@ module Qs
       callbacks.each{ |proc| self.handler.instance_eval(&proc) }
     end
 
+    module OptionalTimeout
+      def self.new(timeout, &block)
+        if !timeout.nil?
+          SystemTimer.timeout_after(timeout, TimeoutError, &block)
+        else
+          block.call
+        end
+      end
+    end
+
   end
+
+  TimeoutError = Class.new(RuntimeError)
 
 end

--- a/test/unit/job_handler_tests.rb
+++ b/test/unit/job_handler_tests.rb
@@ -10,6 +10,7 @@ module Qs::JobHandler
     end
     subject{ @handler_class }
 
+    should have_imeths :timeout
     should have_imeths :before_callbacks, :after_callbacks
     should have_imeths :before_init_callbacks, :after_init_callbacks
     should have_imeths :before_run_callbacks,  :after_run_callbacks
@@ -19,6 +20,19 @@ module Qs::JobHandler
     should have_imeths :prepend_before, :prepend_after
     should have_imeths :prepend_before_init, :prepend_after_init
     should have_imeths :prepend_before_run,  :prepend_after_run
+
+    should "allow reading/writing its timeout" do
+      assert_nil subject.timeout
+      value = Factory.integer
+      subject.timeout(value)
+      assert_equal value, subject.timeout
+    end
+
+    should "convert timeout values to floats" do
+      value = Factory.float.to_s
+      subject.timeout(value)
+      assert_equal value.to_f, subject.timeout
+    end
 
     should "return an empty array by default using `before_callbacks`" do
       assert_equal [], subject.before_callbacks

--- a/test/unit/qs_tests.rb
+++ b/test/unit/qs_tests.rb
@@ -125,7 +125,7 @@ module Qs
     end
     subject{ @config }
 
-    should have_options :serializer, :deserializer
+    should have_options :serializer, :deserializer, :timeout
     should have_namespace :redis
 
     should "know its default serializer/deserializer" do
@@ -136,6 +136,10 @@ module Qs
       assert_equal exp, serialized_payload
       exp = JSON.load(exp)
       assert_equal exp, subject.deserializer.call(serialized_payload)
+    end
+
+    should "know its default timeout" do
+      assert_nil subject.timeout
     end
 
     should "know its default redis options" do


### PR DESCRIPTION
This adds job timeouts that can be configured globally for all jobs
or on individual jobs. This allows controlling run-away jobs that
will never end. If a timeout value is given, then `SystemTimer`
is used to ensure the job doesn't run past the value. A
`Qs::TimeoutError` is thrown if it does. If a timeout value isn't
given, then the job will be allowed to run indefinitely. Finally,
a specific timeout for a handler will be used over the globally
configured timeout.

@kellyredding - Ready for review.