### PR TITLE
Change restart cmd to check if `ENV['PWD']` is set

### DIFF
--- a/bench/report.txt
+++ b/bench/report.txt
@@ -5,7 +5,7 @@ Adding jobs
 Running jobs
 ....................................................................................................
 
-Adding 10000 Jobs Time:   1.6252s
-Running 10000 Jobs Time: 12.4884s
+Adding 10000 Jobs Time:   1.6065s
+Running 10000 Jobs Time: 12.1003s
 
 Done running benchmark report

--- a/lib/qs/process.rb
+++ b/lib/qs/process.rb
@@ -38,7 +38,7 @@ module Qs
       thread = @daemon.start
       log "#{@daemon.name} daemon started and ready."
       thread.join
-      exec_restart_cmd if self.restart?
+      run_restart_cmd if self.restart?
     rescue StandardError => exception
       log "Error: #{exception.message}"
       log "#{@daemon.name} daemon never started."
@@ -60,10 +60,10 @@ module Qs
       @logger.info "[Qs] #{message}"
     end
 
-    def exec_restart_cmd
+    def run_restart_cmd
       log "Restarting #{@daemon.name} daemon..."
       ENV['QS_SKIP_DAEMONIZE'] = 'yes'
-      @restart_cmd.exec
+      @restart_cmd.run
     end
 
     def default_if_blank(value, default, &block)
@@ -83,21 +83,22 @@ module Qs
     def initialize
       require 'rubygems'
       @dir  = get_pwd
-      @argv = [ Gem.ruby, $0, ARGV.dup ].flatten
+      @argv = [Gem.ruby, $0, ARGV.dup].flatten
     end
 
-    def exec
+    def run
       Dir.chdir self.dir
       Kernel.exec(*self.argv)
     end
 
-    protected
+    private
 
     # Trick from puma/unicorn. Favor PWD because it contains an unresolved
     # symlink. This is useful when restarting after deploying; the original
     # directory may be removed, but the symlink is pointing to a new
     # directory.
     def get_pwd
+      return Dir.pwd if ENV['PWD'].nil?
       env_stat = File.stat(ENV['PWD'])
       pwd_stat = File.stat(Dir.pwd)
       if env_stat.ino == pwd_stat.ino && env_stat.dev == pwd_stat.dev


### PR DESCRIPTION
This changes the restart cmd to check if `ENV['PWD']` is set
before it tries to stat it. This covers the rare case where the
env var isn't set, like when using sudo. This piece of code is
heavily influenced by puma and I copied the checking from them as
well.

This also updates the `RestartCmd` and changes its `exec` method to
just `run`. This is simpler and fits more of our standard pattern
of initializing and running classes. This also reworks the tests to
properly test all the behavior with restart cmd. This wasn't done
previously most likely because it is relatively difficult to test
because of the number of stubs and because its mostly edge case
behavior.

@kellyredding - Ready for review. This is really minor and doesn't effect our usage. I just saw this change in puma and thought I'd bring it over. I'm going to make the same changes to Sanford.