### PR TITLE
Expand `ErrorHandler` to take more information

### DIFF
--- a/bench/report.txt
+++ b/bench/report.txt
@@ -5,7 +5,7 @@ Adding jobs
 Running jobs
 ....................................................................................................
 
-Adding 10000 Jobs Time:   1.6065s
-Running 10000 Jobs Time: 12.1003s
+Adding 10000 Jobs Time:   1.5660s
+Running 10000 Jobs Time: 12.2320s
 
 Done running benchmark report

--- a/qs.gemspec
+++ b/qs.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency("ns-options",      ["~> 1.1"])
   gem.add_dependency("SystemTimer",     ["~> 1.2"])
 
-  gem.add_development_dependency("assert", ["~> 2.12"])
+  gem.add_development_dependency("assert", ["~> 2.14"])
   gem.add_development_dependency("scmd",   ["~> 2.3"])
 end

--- a/test/support/app_daemon.rb
+++ b/test/support/app_daemon.rb
@@ -20,8 +20,8 @@ class AppDaemon
 
   queue AppQueue
 
-  error do |exception, daemon_data, job|
-    job_name = job.name if job
+  error do |exception, context|
+    job_name = context.job.name if context.job
     case(job_name)
     when 'error', 'timeout'
       message = "#{exception.class}: #{exception.message}"


### PR DESCRIPTION
This updates the `ErrorHandler` to take more information about the
job that failed. This includes passing the queue that the job
came from, the serialized payload of the job and the handler
class that was being used to run it. The handler class can be `nil`
if the error happened before a handler class was found.

These are being added to expand the functionality of the error
handler and to help with handling errors that happen before a job
is deserialized. Specifically, this is setup for changing how the
hard shutdown feature works. A new version of dat worker pool will
raise an exception on worker threads that are running jobs when it
attempts to force a shutdown. This means an exception can happen
at any point, even before a job has been deserialized. For this
case, we still want to get the serialized payload so we can add
the job back to the queue because it never had a chance to run.
By passing the queue key and serialized payload to the error
handler this will be possible.

This also updates to the latest assert to keep up-to-date and to
use its latest features.

@kellyredding - Ready for review.