### PR TITLE
Expand redis item to track the state of processing it

### DIFF
--- a/bench/report.txt
+++ b/bench/report.txt
@@ -5,7 +5,7 @@ Adding jobs
 Running jobs
 ....................................................................................................
 
-Adding 10000 Jobs Time:   1.5660s
-Running 10000 Jobs Time: 12.2320s
+Adding 10000 Jobs Time:   1.6297s
+Running 10000 Jobs Time: 12.2247s
 
 Done running benchmark report

--- a/lib/qs/daemon.rb
+++ b/lib/qs/daemon.rb
@@ -8,6 +8,7 @@ require 'qs'
 require 'qs/daemon_data'
 require 'qs/logger'
 require 'qs/payload_handler'
+require 'qs/redis_item'
 
 module Qs
 
@@ -88,11 +89,7 @@ module Qs
       private
 
       def process(redis_item)
-        Qs::PayloadHandler.new(
-          self.daemon_data,
-          redis_item.queue_key,
-          redis_item.serialized_payload
-        ).run
+        Qs::PayloadHandler.new(self.daemon_data, redis_item).run
       end
 
       def work_loop
@@ -293,8 +290,6 @@ module Qs
         @valid = true
       end
     end
-
-    RedisItem = Struct.new(:queue_key, :serialized_payload)
 
     class IOPipe
       NULL   = File.open('/dev/null', 'w')

--- a/lib/qs/error_handler.rb
+++ b/lib/qs/error_handler.rb
@@ -1,3 +1,5 @@
+require 'qs/queue'
+
 module Qs
 
   class ErrorHandler
@@ -29,12 +31,12 @@ module Qs
 
   class ErrorContext
     attr_reader :daemon_data
-    attr_reader :queue_redis_key, :serialized_payload
+    attr_reader :queue_name, :serialized_payload
     attr_reader :job, :handler_class
 
     def initialize(args)
       @daemon_data        = args[:daemon_data]
-      @queue_redis_key    = args[:queue_redis_key]
+      @queue_name         = Queue::RedisKey.parse_name(args[:queue_redis_key].to_s)
       @serialized_payload = args[:serialized_payload]
       @job                = args[:job]
       @handler_class      = args[:handler_class]
@@ -43,7 +45,7 @@ module Qs
     def ==(other)
       if other.kind_of?(self.class)
         self.daemon_data        == other.daemon_data &&
-        self.queue_redis_key    == other.queue_redis_key &&
+        self.queue_name         == other.queue_name &&
         self.serialized_payload == other.serialized_payload &&
         self.job                == other.job &&
         self.handler_class      == other.handler_class

--- a/lib/qs/queue.rb
+++ b/lib/qs/queue.rb
@@ -21,7 +21,7 @@ module Qs
     end
 
     def redis_key
-      @redis_key ||= "queues:#{name}"
+      @redis_key ||= RedisKey.new(self.name)
     end
 
     def job_handler_ns(value = nil)
@@ -54,6 +54,16 @@ module Qs
     end
 
     InvalidError = Class.new(RuntimeError)
+
+    module RedisKey
+      def self.parse_name(key)
+        key.split(':').last
+      end
+
+      def self.new(name)
+        "queues:#{name}"
+      end
+    end
 
   end
 

--- a/lib/qs/redis_item.rb
+++ b/lib/qs/redis_item.rb
@@ -1,0 +1,33 @@
+module Qs
+
+  class RedisItem
+
+    attr_reader :queue_redis_key, :serialized_payload
+    attr_accessor :started, :finished
+    attr_accessor :job, :handler_class
+    attr_accessor :exception, :time_taken
+
+    def initialize(queue_redis_key, serialized_payload)
+      @queue_redis_key    = queue_redis_key
+      @serialized_payload = serialized_payload
+      @started            = false
+      @finished           = false
+
+      @job           = nil
+      @handler_class = nil
+      @exception     = nil
+      @time_taken    = nil
+    end
+
+    def ==(other)
+      if other.kind_of?(self.class)
+        self.queue_redis_key    == other.queue_redis_key &&
+        self.serialized_payload == other.serialized_payload
+      else
+        super
+      end
+    end
+
+  end
+
+end

--- a/test/unit/queue_tests.rb
+++ b/test/unit/queue_tests.rb
@@ -35,7 +35,7 @@ class Qs::Queue
 
     should "know its redis key" do
       result = subject.redis_key
-      assert_equal "queues:#{subject.name}", result
+      assert_equal RedisKey.new(subject.name), result
       assert_same result, subject.redis_key
     end
 
@@ -108,6 +108,23 @@ class Qs::Queue
       exp = [subject, @job_name, @job_params]
       assert_equal exp, @enqueue_args
       assert_equal @enqueue_args, result
+    end
+
+  end
+
+  class RedisKeyTests < UnitTests
+    desc "RedisKey"
+    subject{ RedisKey }
+
+    should have_imeths :parse_name, :new
+
+    should "know how to build a redis key" do
+      assert_equal "queues:#{@queue.name}", subject.new(@queue.name)
+    end
+
+    should "know how to parse a queue name from a key" do
+      redis_key = subject.new(@queue.name)
+      assert_equal @queue.name, subject.parse_name(redis_key)
     end
 
   end

--- a/test/unit/redis_item_tests.rb
+++ b/test/unit/redis_item_tests.rb
@@ -1,0 +1,49 @@
+require 'assert'
+require 'qs/redis_item'
+
+class Qs::RedisItem
+
+  class UnitTests < Assert::Context
+    desc "Qs::RedisItem"
+    setup do
+      @queue_redis_key    = Factory.string
+      @serialized_payload = Factory.string
+      @redis_item = Qs::RedisItem.new(@queue_redis_key, @serialized_payload)
+    end
+    subject{ @redis_item }
+
+    should have_readers :queue_redis_key, :serialized_payload
+    should have_accessors :started, :finished
+    should have_accessors :job, :handler_class
+    should have_accessors :exception, :time_taken
+
+    should "know its queue redis key and serialized payload" do
+      assert_equal @queue_redis_key,    subject.queue_redis_key
+      assert_equal @serialized_payload, subject.serialized_payload
+    end
+
+    should "defaults its other attributes" do
+      assert_false subject.started
+      assert_false subject.finished
+
+      assert_nil subject.job
+      assert_nil subject.handler_class
+      assert_nil subject.exception
+      assert_nil subject.time_taken
+    end
+
+    should "know if it equals another item" do
+      exp = Qs::RedisItem.new(@queue_redis_key, @serialized_payload)
+      assert_equal exp, subject
+
+      redis_key = Qs::Queue::RedisKey.new(Factory.string)
+      exp = Qs::RedisItem.new(redis_key, @serialized_payload)
+      assert_not_equal exp, subject
+
+      exp = Qs::RedisItem.new(@queue_redis_key, Factory.string)
+      assert_not_equal exp, subject
+    end
+
+  end
+
+end


### PR DESCRIPTION
This expands the redis item to not be a simple struct and to
instead track all of the state of processing it. This includes the
job and handler class that were used to run it (if we were able to
deserialize it and route it), the exception that it generated
(again, only if one was thrown) and the time it took to run it.
This is setup for a new dat worker pool that better handles hard
shutdowns and allows custom error handling.

By making the redis item track its state, we can add error handling
to dat worker pool. The error handling can be smart and use the
redis items state to make decisions. For example, if a job was
never started, we can requeue it. This ensures Qs can do its best
to not "lose" any jobs because of errors, specifically when its
being forced to shutdown.

This also changes the error context to change a queue redis key to
a queue name. In general, the redis key is intended to be internal,
so the user-defined error procs shouldn't be working with it
directly.

@kellyredding - Ready for review.