### PR TITLE
Add `push` and `prepend` to `Client`

### DIFF
--- a/lib/qs/client.rb
+++ b/lib/qs/client.rb
@@ -34,6 +34,14 @@ module Qs
         job
       end
 
+      def append(queue_redis_key, serialized_payload)
+        self.redis.with{ |c| c.lpush(queue_redis_key, serialized_payload) }
+      end
+
+      def prepend(queue_redis_key, serialized_payload)
+        self.redis.with{ |c| c.rpush(queue_redis_key, serialized_payload) }
+      end
+
     end
 
   end
@@ -50,7 +58,7 @@ module Qs
 
     def enqueue!(queue, job)
       serialized_payload = Qs.serialize(job.to_payload)
-      self.redis.with{ |c| c.lpush(queue.redis_key, serialized_payload) }
+      self.append(queue.redis_key, serialized_payload)
     end
 
   end


### PR DESCRIPTION
This adds a `push` and `prepend` method to clients. This will be
used to requeue redis items. If a redis item fails before it has
been started, or if a redis item is left on the dat worker pool
when its shutdown, we want to requeue this work before exiting. To
facilitate this, clients now have low-level push and prepend
methods that will take the raw components of a redis item: a queue
redis key and a serialized payload. This will either add the item
to the front or back of the queue.

The `push` and `prepend` methods were not added to the `Qs` module
because they aren't intended for "public" use. The components they
require are not easily available to end-users and require knowledge
of how Qs works to build properly.

@kellyredding - Ready for review.