### PR TITLE
Update `Daemon` to build a client instead of a redis connection

### DIFF
--- a/bench/report.txt
+++ b/bench/report.txt
@@ -5,7 +5,7 @@ Adding jobs
 Running jobs
 ....................................................................................................
 
-Adding 10000 Jobs Time:   1.6297s
-Running 10000 Jobs Time: 12.2247s
+Adding 10000 Jobs Time:   1.6035s
+Running 10000 Jobs Time: 12.3163s
 
 Done running benchmark report

--- a/lib/qs/client.rb
+++ b/lib/qs/client.rb
@@ -34,12 +34,20 @@ module Qs
         job
       end
 
+      def block_dequeue(*args)
+        self.redis.with{ |c| c.brpop(*args) }
+      end
+
       def append(queue_redis_key, serialized_payload)
         self.redis.with{ |c| c.lpush(queue_redis_key, serialized_payload) }
       end
 
       def prepend(queue_redis_key, serialized_payload)
         self.redis.with{ |c| c.rpush(queue_redis_key, serialized_payload) }
+      end
+
+      def clear(redis_key)
+        self.redis.with{ |c| c.del(redis_key) }
       end
 
     end


### PR DESCRIPTION
This updates the `Daemon` to build a client instead of a redis
connection directly. This is setup for adding a new dat worker
pool. The new dat worker pool changes the shutdown process and
Qs will requeue jobs that were forced to shutdown and didn't
get started and it will also requeue any work left on dat worker
pool's queue. To facilitate this, its better for the daemon to
have a client so it can add jobs to a queue the same way it is
done elsewhere. This also builds the client with enough
connections for each worker to need to requeue a job.

This also fixes an issue with "queue starvation" by shuffling the
keys that are passed when pulling work off a queue. If this isn't
done, then the same queue is always first in the list which means
any queues behind it may never run jobs if it is always full. By
shuffling them they all get a chance to have work pulled from
them.

@kellyredding - Ready for review. Because we are now shuffling everytime we pop work from the queue there was an expected slowdown. The benchmarks seem to be consistently 1/10th of a second slower.