### PR TITLE
Update to the latest `DatWorkerPool`

### DIFF
--- a/bench/report.txt
+++ b/bench/report.txt
@@ -5,7 +5,7 @@ Adding jobs
 Running jobs
 ....................................................................................................
 
-Adding 10000 Jobs Time:   1.6035s
-Running 10000 Jobs Time: 12.3163s
+Adding 10000 Jobs Time:   1.6041s
+Running 10000 Jobs Time: 12.3159s
 
 Done running benchmark report

--- a/qs.gemspec
+++ b/qs.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency("dat-worker-pool", ["~> 0.4"])
+  gem.add_dependency("dat-worker-pool", ["~> 0.5"])
   gem.add_dependency("hella-redis",     ["~> 0.2"])
   gem.add_dependency("ns-options",      ["~> 1.1"])
   gem.add_dependency("SystemTimer",     ["~> 1.2"])

--- a/test/system/daemon_tests.rb
+++ b/test/system/daemon_tests.rb
@@ -12,20 +12,30 @@ module Qs::Daemon
       @qs_test_mode = ENV['QS_TEST_MODE']
       ENV['QS_TEST_MODE'] = nil
       Qs.init
-
-      @daemon = AppDaemon.new
-      @daemon_runner = DaemonRunner.new(@daemon).tap(&:start)
+      @orig_config = AppDaemon.configuration.to_hash
     end
     teardown do
-      @daemon_runner.stop
+      @daemon_runner.stop if @daemon_runner
+      AppDaemon.configuration.apply(@orig_config) # reset daemon config
+      Qs.redis.with{ |c| c.del('slow') }
       Qs.redis.with{ |c| c.del('last_error') }
+      Qs.client.clear(AppQueue.redis_key)
       Qs.reset!
       ENV['QS_TEST_MODE'] = @qs_test_mode
     end
 
   end
 
-  class BasicJobTests < SystemTests
+  class RunningDaemonSetupTests < SystemTests
+    setup do
+      @daemon = AppDaemon.new
+      @daemon_runner = DaemonRunner.new(@daemon)
+      @thread = @daemon_runner.start
+    end
+
+  end
+
+  class BasicJobTests < RunningDaemonSetupTests
     desc "with a basic job added"
     setup do
       @key, @value = [Factory.string, Factory.string]
@@ -33,42 +43,166 @@ module Qs::Daemon
         'key'   => @key,
         'value' => @value
       })
+      @thread.join 0.5
     end
 
     should "run the job" do
-      sleep 0.5
       assert_equal @value, Qs.redis.with{ |c| c.get(@key) }
     end
 
   end
 
-  class JobThatErrorsTests < SystemTests
+  class JobThatErrorsTests < RunningDaemonSetupTests
     desc "with a job that errors"
     setup do
       @error_message = Factory.text
       AppQueue.add('error', 'error_message' => @error_message)
+      @thread.join 0.5
     end
 
     should "run the configured error handler procs" do
-      sleep 0.5
       exp = "RuntimeError: #{@error_message}"
       assert_equal exp, Qs.redis.with{ |c| c.get('last_error') }
     end
 
   end
 
-  class TimeoutJobTests < SystemTests
+  class TimeoutJobTests < RunningDaemonSetupTests
     desc "with a job that times out"
     setup do
       AppQueue.add('timeout')
+      @thread.join 1 # let the daemon have time to process the job
     end
 
     should "run the configured error handler procs" do
-      sleep 1
       handler_class = AppHandlers::Timeout
       exp = "Qs::TimeoutError: #{handler_class} timed out " \
             "(#{handler_class.timeout}s)"
       assert_equal exp, Qs.redis.with{ |c| c.get('last_error') }
+    end
+
+  end
+
+  class NoWorkersAvailableTests < SystemTests
+    desc "when no workers are available"
+    setup do
+      AppDaemon.workers 0 # no workers available, don't do this
+      @daemon = AppDaemon.new
+      @daemon_runner = DaemonRunner.new(@daemon)
+      @thread = @daemon_runner.start
+    end
+
+    should "shutdown when stopped" do
+      @daemon.stop
+      @thread.join 2 # give it time to shutdown, should be faster
+      assert_false @thread.alive?
+    end
+
+    should "shutdown when halted" do
+      @daemon.halt
+      @thread.join 2 # give it time to shutdown, should be faster
+      assert_false @thread.alive?
+    end
+
+  end
+
+  class ShutdownWithoutTimeoutTests < SystemTests
+    desc "without a shutdown timeout"
+    setup do
+      AppDaemon.shutdown_timeout nil # disable shutdown timeout
+      @daemon = AppDaemon.new
+      @daemon_runner = DaemonRunner.new(@daemon)
+      @thread = @daemon_runner.start
+
+      AppQueue.add('slow')
+      @thread.join 1 # let the daemon have time to process the job
+    end
+
+    should "shutdown and let the job finished" do
+      @daemon.stop
+      @thread.join 10 # give it time to shutdown, should be faster
+      assert_false @thread.alive?
+      assert_equal 'finished', Qs.redis.with{ |c| c.get('slow') }
+    end
+
+    should "shutdown and not let the job finished" do
+      @daemon.halt
+      @thread.join 2 # give it time to shutdown, should be faster
+      assert_false @thread.alive?
+      assert_nil Qs.redis.with{ |c| c.get('slow') }
+      exp = "Qs::ShutdownError"
+      assert_equal exp, Qs.redis.with{ |c| c.get('last_error') }
+    end
+
+  end
+
+  class ShutdownWithTimeoutTests < SystemTests
+    desc "with a shutdown timeout"
+    setup do
+      AppDaemon.shutdown_timeout 1
+      @daemon = AppDaemon.new
+      @daemon_runner = DaemonRunner.new(@daemon)
+      @thread = @daemon_runner.start
+
+      AppQueue.add('slow')
+      @thread.join 1 # let the daemon have time to process the job
+    end
+
+    should "shutdown and not let the job finished" do
+      @daemon.stop
+      @thread.join 2 # give it time to shutdown, should be faster
+      assert_false @thread.alive?
+      assert_nil Qs.redis.with{ |c| c.get('slow') }
+      exp = "Qs::ShutdownError"
+      assert_equal exp, Qs.redis.with{ |c| c.get('last_error') }
+    end
+
+    should "shutdown and not let the job finished" do
+      @daemon.halt
+      @thread.join 2 # give it time to shutdown, should be faster
+      assert_false @thread.alive?
+      assert_nil Qs.redis.with{ |c| c.get('slow') }
+      exp = "Qs::ShutdownError"
+      assert_equal exp, Qs.redis.with{ |c| c.get('last_error') }
+    end
+
+  end
+
+  class ShutdownWithUnprocessedRedisItemTests < SystemTests
+    desc "with a redis item that gets picked up but doesn't get processed"
+    setup do
+      Assert.stub(Qs::PayloadHandler, :new){ sleep 5 }
+
+      AppDaemon.shutdown_timeout 1
+      AppDaemon.workers 2
+      @daemon = AppDaemon.new
+      @daemon_runner = DaemonRunner.new(@daemon)
+      @thread = @daemon_runner.start
+
+      AppQueue.add('slow')
+      AppQueue.add('slow')
+      AppQueue.add('basic')
+      @thread.join 1 # let the daemon have time to process jobs
+    end
+
+    should "shutdown and requeue the redis item" do
+      @daemon.stop
+      @thread.join 2 # give it time to shutdown, should be faster
+      assert_false @thread.alive?
+      # TODO - better way to read whats on a queue
+      serialized_payloads = Qs.redis.with{ |c| c.lrange(AppQueue.redis_key, 0, 3) }
+      names = serialized_payloads.map{ |sp| Qs::Job.parse(Qs.deserialize(sp)).name }
+      assert_equal ['basic', 'slow', 'slow'], names
+    end
+
+    should "shutdown and requeue the redis item" do
+      @daemon.halt
+      @thread.join 2 # give it time to shutdown, should be faster
+      assert_false @thread.alive?
+      # TODO - better way to read whats on a queue
+      serialized_payloads = Qs.redis.with{ |c| c.lrange(AppQueue.redis_key, 0, 3) }
+      names = serialized_payloads.map{ |sp| Qs::Job.parse(Qs.deserialize(sp)).name }
+      assert_equal ['basic', 'slow', 'slow'], names
     end
 
   end


### PR DESCRIPTION
This updates to the latest `DatWorkerPool` which includes on worker
error callbacks and better shutdown behavior. The worker pool is
now configured with an on error callback and is always shutdown,
even when halting. This is part of an effort to better handle
shutting down with a timeout and ensuring that jobs aren't lost.

An on-error callback is configured on the worker pool to catch any
errors that happen outside running the payload handler. The only
known use-case for this is when the worker pools shutdown times
out. In this case, the worker pool will raise errors on its workers
threads. These errors can be raised at anytime, which means they
can occur outside running a payload handler. The on-error callback
will requeue any jobs that the worker pulled off but didn't start
processing. If the worker started processing the job, then the
on-error callback won't receive the exception because the payload
handler will catch it and do the normal error handling logic.

The daemon shutdown behavior is also being changed with the new
dat worker pool. The worker pool is now always shutdown. The only
difference is if the daemon is halted, it will shutdown the worker
pool immediately instead of using the configured timeout. Once the
worker pool has shutdown, the daemon will also requeue any redis
items left on the pool. This is being done instead of the previous
logic that tried to wait until the queue emptied.

Finally, this also fixes a minor issue where the `NULL` IO pipe
could get closed. This happened in the test suite and caused
random tests to fail.

@kellyredding - Ready for review.