### PR TITLE
Test helpers, serialize when enqueuing and building test runner

### DIFF
--- a/lib/qs/client.rb
+++ b/lib/qs/client.rb
@@ -108,6 +108,9 @@ module Qs
     private
 
     def enqueue!(queue, job)
+      # attempt to serialize (and then throw away) the job payload, this will
+      # error on the developer if it can't serialize the job
+      Qs.serialize(job.to_payload)
       queue.enqueued_jobs << job
     end
 

--- a/lib/qs/job.rb
+++ b/lib/qs/job.rb
@@ -18,7 +18,7 @@ module Qs
 
     def to_payload
       { 'name'       => self.name.to_s,
-        'params'     => stringify(self.params),
+        'params'     => StringifyParams.new(self.params),
         'created_at' => self.created_at.to_i
       }
     end
@@ -50,14 +50,16 @@ module Qs
       raise(BadJobError, problem) if problem
     end
 
-    def stringify(object)
-      case(object)
-      when Hash
-        object.inject({}){ |h, (k, v)| h.merge(k.to_s => stringify(v)) }
-      when Array
-        object.map{ |item| stringify(item) }
-      else
-        object
+    module StringifyParams
+      def self.new(object)
+        case(object)
+        when Hash
+          object.inject({}){ |h, (k, v)| h.merge(k.to_s => self.new(v)) }
+        when Array
+          object.map{ |item| self.new(item) }
+        else
+          object
+        end
       end
     end
 

--- a/lib/qs/test_runner.rb
+++ b/lib/qs/test_runner.rb
@@ -1,3 +1,5 @@
+require 'qs'
+require 'qs/job'
 require 'qs/job_handler'
 require 'qs/runner'
 
@@ -15,7 +17,7 @@ module Qs
       args = (args || {}).dup
       super(handler_class, {
         :job    => args.delete(:job),
-        :params => args.delete(:params),
+        :params => normalize_params(args.delete(:params) || {}),
         :logger => args.delete(:logger)
       })
       args.each{ |key, value| self.handler.send("#{key}=", value) }
@@ -25,6 +27,15 @@ module Qs
 
     def run
       self.handler.run
+    end
+
+    private
+
+    # Stringify and serialize/deserialize to ensure params are valid and are
+    # in the format they would normally be when a handler is built and run.
+    def normalize_params(params)
+      params = Job::StringifyParams.new(params)
+      Qs.deserialize(Qs.serialize(params))
     end
 
   end

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -1,12 +1,18 @@
 require 'assert'
 require 'qs/test_runner'
 
+require 'qs'
+
 class Qs::TestRunner
 
   class UnitTests < Assert::Context
     desc "Qs::TestRunner"
     setup do
+      Qs.init
       @runner_class = Qs::TestRunner
+    end
+    teardown do
+      Qs.reset!
     end
     subject{ @runner_class }
 
@@ -62,6 +68,20 @@ class Qs::TestRunner
 
     should "not call its job handler's after callbacks" do
       assert_nil @handler.after_called
+    end
+
+    should "stringify and serialize the params passed to it" do
+      key, value = Factory.string.to_sym, Factory.string
+      params = {
+        key    => value,
+        'date' => Date.today
+      }
+      runner = @runner_class.new(@handler_class, :params => params)
+      exp = {
+        key.to_s => value,
+        'date'   => params['date'].to_s
+      }
+      assert_equal exp, runner.params
     end
 
     should "raise an invalid error when not passed a job handler" do


### PR DESCRIPTION
This updates the testing tools to serialize when enqueuing jobs
with the test client and when building a test runner. This ensures
the jobs being enqueued are valid and will work when enqueuing
them in production. This also ensures the params being used to
test a handler are valid and are what can be expected in
production. This is to improve the testing tools.

@kellyredding - Ready for review. You may have gotten a duplicate hotfix email, I accidentally pushed this to master and had to reset it back to the hotfix commit. Sorry for the noise.