### PR TITLE
Add `Qs.push` for adding payloads to queues given a queue name

### DIFF
--- a/lib/qs.rb
+++ b/lib/qs.rb
@@ -39,6 +39,10 @@ module Qs
     @client.enqueue(queue, job_name, params)
   end
 
+  def self.push(queue_name, payload)
+    @client.push(queue_name, payload)
+  end
+
   def self.serialize(payload)
     @serializer.call(payload)
   end


### PR DESCRIPTION
This adds `Qs.push` which is a lower-level method for adding
payloads to a queue. This is future setup for retrying and events
but is currently useful for custom error handlers. When a job
fails, users may be using an error tracker. The error tracker can
be provided enough information so that it can retry a job manually
using `Qs.push`. Typically, a separate app will not have access to
the `Queue` object so it can't use `enqueue`. This allows adding
jobs to queues without having a `Queue` instance. This is less
safe than using the `enqueue` method and should only be used for
special circumstances.

@kellyredding - Ready for review.