### PR TITLE
Pull out `IOPipe`, setup for use in the `Process`

### DIFF
--- a/lib/qs/io_pipe.rb
+++ b/lib/qs/io_pipe.rb
@@ -1,0 +1,40 @@
+module Qs
+
+  class IOPipe
+
+    NULL = File.open('/dev/null', 'w')
+
+    attr_reader :reader, :writer
+
+    def initialize
+      @reader = NULL
+      @writer = NULL
+    end
+
+    def setup
+      @reader, @writer = ::IO.pipe
+    end
+
+    def teardown
+      @reader.close unless @reader === NULL
+      @writer.close unless @writer === NULL
+      @reader = NULL
+      @writer = NULL
+    end
+
+    def read
+      @reader.gets.strip
+    end
+
+    def write(value)
+      @writer.puts(value)
+    end
+
+    def wait
+      ::IO.select([@reader])
+      self
+    end
+
+  end
+
+end

--- a/test/unit/daemon_tests.rb
+++ b/test/unit/daemon_tests.rb
@@ -565,54 +565,6 @@ module Qs::Daemon
 
   end
 
-  class IOPipeTests < UnitTests
-    desc "IOPipe"
-    setup do
-      @io = IOPipe.new
-    end
-    subject{ @io }
-
-    should have_readers :reader, :writer
-    should have_imeths :wait, :signal
-    should have_imeths :setup, :teardown
-
-    should "default its reader and writer" do
-      assert_same IOPipe::NULL, subject.reader
-      assert_same IOPipe::NULL, subject.writer
-    end
-
-    should "be able to wait until signalled" do
-      subject.setup
-
-      thread = Thread.new{ subject.wait }
-      thread.join(0.1)
-      assert_equal 'sleep', thread.status
-
-      subject.signal
-      thread.join
-      assert_false thread.status
-    end
-
-    should "set its reader and writer to an IO pipe when setup" do
-      subject.setup
-      assert_instance_of ::IO, subject.reader
-      assert_instance_of ::IO, subject.writer
-    end
-
-    should "close its reader/writer and set them to defaults when torn down" do
-      subject.setup
-      reader = subject.reader
-      writer = subject.writer
-
-      subject.teardown
-      assert_true reader.closed?
-      assert_true writer.closed?
-      assert_same IOPipe::NULL, subject.reader
-      assert_same IOPipe::NULL, subject.writer
-    end
-
-  end
-
   class SignalTests < UnitTests
     desc "Signal"
     setup do

--- a/test/unit/io_pipe_tests.rb
+++ b/test/unit/io_pipe_tests.rb
@@ -1,0 +1,68 @@
+require 'assert'
+require 'qs/io_pipe'
+
+require 'thread'
+
+class Qs::IOPipe
+
+  class UnitTests < Assert::Context
+    desc "Qs::IOPipe"
+    setup do
+      @io_pipe = Qs::IOPipe.new
+    end
+    subject{ @io_pipe }
+
+    should have_readers :reader, :writer
+    should have_imeths :setup, :teardown
+    should have_imeths :read, :write, :wait
+
+    should "default its reader and writer" do
+      assert_same NULL, subject.reader
+      assert_same NULL, subject.writer
+    end
+
+    should "change its reader/writer to an IO pipe when setup" do
+      subject.setup
+      assert_not_same NULL, subject.reader
+      assert_not_same NULL, subject.writer
+      assert_instance_of IO, subject.reader
+      assert_instance_of IO, subject.writer
+    end
+
+    should "close its reader/writer and set them to defaults when torn down" do
+      subject.setup
+      reader = subject.reader
+      writer = subject.writer
+
+      subject.teardown
+      assert_true reader.closed?
+      assert_true writer.closed?
+      assert_same NULL, subject.reader
+      assert_same NULL, subject.writer
+    end
+
+    should "be able to read/write values" do
+      subject.setup
+
+      value = Factory.string
+      subject.write(value)
+      assert_equal value, subject.read
+    end
+
+    should "be able to wait until there is something to read" do
+      subject.setup
+
+      result = nil
+      thread = Thread.new{ result = subject.wait }
+      thread.join(0.1)
+      assert_equal 'sleep', thread.status
+
+      subject.write(Factory.string)
+      thread.join
+      assert_false thread.status
+      assert_equal subject, result
+    end
+
+  end
+
+end


### PR DESCRIPTION
This pulls out the `IOPipe` so that it can be used in the
`Process`. This slightly changes its API as well and updates
the `Daemon` to work with the changes. All of this is setup for
changing how Qs handles unix signals.

In a future PR, the `Process` will instead of joining the daemons
thread to the main thread, it will start a loop where it listens
for signals on an `IOPipe`. The signal traps will be changed to be
super simple and only write to the `IOPipe`. The benefit of this is
its a best practice to limit what is done in a signal trap as much
as possible. The current implementation does this as much as
possible but it still writes to a redis signal queue, the worker
available io and it sets state on the daemon. The concern is that
multiple traps can run at the same time which can cause the system
to get into bad states. The current implementation takes extra
steps to avoid this that can be simplified once the signal handling
is changed.

@kellyredding - Ready for review.