### PR TITLE
Don't use `gets` and `puts` in `IOPipe`

### DIFF
--- a/lib/qs/io_pipe.rb
+++ b/lib/qs/io_pipe.rb
@@ -3,6 +3,7 @@ module Qs
   class IOPipe
 
     NULL = File.open('/dev/null', 'w')
+    NUMBER_OF_BYTES = 1
 
     attr_reader :reader, :writer
 
@@ -23,11 +24,11 @@ module Qs
     end
 
     def read
-      @reader.gets.strip
+      @reader.read_nonblock(NUMBER_OF_BYTES)
     end
 
     def write(value)
-      @writer.puts(value)
+      @writer.write_nonblock(value[0, NUMBER_OF_BYTES])
     end
 
     def wait

--- a/test/unit/io_pipe_tests.rb
+++ b/test/unit/io_pipe_tests.rb
@@ -44,9 +44,17 @@ class Qs::IOPipe
     should "be able to read/write values" do
       subject.setup
 
-      value = Factory.string
+      value = Factory.string(NUMBER_OF_BYTES)
       subject.write(value)
       assert_equal value, subject.read
+    end
+
+    should "only read/write a fixed number of bytes" do
+      subject.setup
+
+      value = Factory.string
+      subject.write(value)
+      assert_equal value[0, NUMBER_OF_BYTES], subject.read
     end
 
     should "be able to wait until there is something to read" do


### PR DESCRIPTION
This changes `IOPipe` from using `gets` and `puts` to instead use
`read_nonblock` and `write_nonblock`. `gets` and `puts` cause
problems because they block. This causes problems and randomly
hangs threads in Ruby 1.8.7. This changes the `IOPipe` to use
`read_nonblock` and `write_nonblock` but also forces writing only
1 byte values.

The `IOPipe` was originally changed to use `gets` and `puts` to
allow the `Process` in a future PR to use it for handling signals.
The signals were going to be written directly to the IO pipe but,
with this change, only a single letter will be written for the
signals.

@kellyredding - Ready for review. Not sure what changed but when I was using the IO pipe changes with the bench script it started hanging. I'm not sure why it was originally working but it got into a state on my machine where it regularly hanged. Sorry for the back and forth on this.