### PR TITLE
Rescue redis errors while dequeueing

### DIFF
--- a/bench/report.txt
+++ b/bench/report.txt
@@ -5,7 +5,7 @@ Adding jobs
 Running jobs
 ....................................................................................................
 
-Adding 10000 Jobs Time:   1.6041s
-Running 10000 Jobs Time: 12.3159s
+Adding 10000 Jobs Time:   1.6155s
+Running 10000 Jobs Time: 12.4848s
 
 Done running benchmark report


### PR DESCRIPTION
This updates the logic for dequeueing to rescue any runtime errors
and allow the work loop to continue running. The benefit of this is
if redis goes down or becomes unavailable, it doesn't shut down the
daemon. To keep the process from thrashing, the work loop will
sleep for a second when it errors. Otherwise, if redis is down it
will loop very quickly and error again.

This also improves the daemon logging to be more consistent with
logging elsewhere in Qs and to be more extensive. It will now log
when a worker error occurs.

@kellyredding - Ready for review.