### PR TITLE
Use constants for halt, stop and restart signals

### DIFF
--- a/lib/qs/process.rb
+++ b/lib/qs/process.rb
@@ -5,6 +5,10 @@ module Qs
 
   class Process
 
+    HALT    = 'H'.freeze
+    STOP    = 'S'.freeze
+    RESTART = 'R'.freeze
+
     attr_reader :daemon, :name
     attr_reader :pid_file, :signal_io, :restart_cmd
 
@@ -41,7 +45,7 @@ module Qs
       end
       @signal_io.teardown
 
-      run_restart_cmd(@daemon, @restart_cmd) if signal == 'R'
+      run_restart_cmd(@daemon, @restart_cmd) if signal == RESTART
     ensure
       @pid_file.remove
     end
@@ -61,9 +65,9 @@ module Qs
     end
 
     def trap_signals(signal_io)
-      trap_signal('INT'){  signal_io.write('H') }
-      trap_signal('TERM'){ signal_io.write('S') }
-      trap_signal('USR2'){ signal_io.write('R') }
+      trap_signal('INT'){  signal_io.write(HALT) }
+      trap_signal('TERM'){ signal_io.write(STOP) }
+      trap_signal('USR2'){ signal_io.write(RESTART) }
     end
 
     def trap_signal(signal, &block)
@@ -82,9 +86,9 @@ module Qs
     def handle_signal(signal, daemon)
       log "Got '#{signal}' signal"
       case signal
-      when 'H'
+      when HALT
         daemon.halt(true)
-      when 'S', 'R'
+      when STOP, RESTART
         daemon.stop(true)
       end
       throw :signal, signal

--- a/test/unit/process_tests.rb
+++ b/test/unit/process_tests.rb
@@ -107,7 +107,7 @@ class Qs::Process
       end
     end
     teardown do
-      @process.signal_io.write('H')
+      @process.signal_io.write(HALT)
       @thread.join if @thread
       $0 = @current_process_name
     end
@@ -189,7 +189,7 @@ class Qs::Process
     desc "and run with a halt signal"
     setup do
       @thread = Thread.new{ @process.run }
-      @process.signal_io.write('H') # send halt signal
+      @process.signal_io.write(HALT)
       @thread.join(0.1)
     end
 
@@ -216,7 +216,7 @@ class Qs::Process
     desc "and run with a stop signal"
     setup do
       @thread = Thread.new{ @process.run }
-      @process.signal_io.write('S') # send stop signal
+      @process.signal_io.write(STOP)
       @thread.join(0.1)
     end
 
@@ -243,7 +243,7 @@ class Qs::Process
     desc "and run with a restart signal"
     setup do
       @thread = Thread.new{ @process.run }
-      @process.signal_io.write('R') # send restart signal
+      @process.signal_io.write(RESTART)
       @thread.join(0.1)
     end
 


### PR DESCRIPTION
This switches to using constants for the halt, stop and restart
signals. This should've been done when they were implemented
because it makes the code more readable. This doesn't change any
functionality.

@kellyredding - Ready for review.