### PR TITLE
Ping redis when starting a daemon

### DIFF
--- a/lib/qs/client.rb
+++ b/lib/qs/client.rb
@@ -55,6 +55,10 @@ module Qs
         self.redis.with{ |c| c.del(redis_key) }
       end
 
+      def ping
+        self.redis.with{ |c| c.ping }
+      end
+
     end
 
   end

--- a/lib/qs/daemon.rb
+++ b/lib/qs/daemon.rb
@@ -71,7 +71,11 @@ module Qs
         !!(@work_loop_thread && @work_loop_thread.alive?)
       end
 
+      # * Ping redis to check that it can communicate with redis before running,
+      #   this is friendlier than starting and continously erroring because it
+      #   can't dequeue.
       def start
+        @client.ping
         @signal.set :start
         @work_loop_thread ||= Thread.new{ work_loop }
       end

--- a/test/unit/client_tests.rb
+++ b/test/unit/client_tests.rb
@@ -127,6 +127,13 @@ module Qs::Client
       assert_equal [@queue_redis_key], call.args
     end
 
+    should "ping redis using `ping`" do
+      subject.ping
+
+      call = @connection_spy.redis_calls.last
+      assert_equal :ping, call.command
+    end
+
   end
 
   class QsClientTests < UnitTests

--- a/test/unit/daemon_tests.rb
+++ b/test/unit/daemon_tests.rb
@@ -218,6 +218,11 @@ module Qs::Daemon
       @thread.join 0.1
     end
 
+    should "ping redis" do
+      call = @client_spy.calls.first
+      assert_equal :ping, call.command
+    end
+
     should "return the thread that is running the daemon" do
       assert_instance_of Thread, @thread
       assert_true @thread.alive?
@@ -228,8 +233,8 @@ module Qs::Daemon
     end
 
     should "clear the signals list in redis" do
-      call = @client_spy.calls.first
-      assert_equal :clear, call.command
+      call = @client_spy.calls.find{ |c| c.command == :clear }
+      assert_not_nil call
       assert_equal [subject.signals_redis_key], call.args
     end
 
@@ -708,6 +713,10 @@ module Qs::Daemon
 
     def clear(*args)
       @calls << Call.new(:clear, args)
+    end
+
+    def ping
+      @calls << Call.new(:ping)
     end
 
     Call = Struct.new(:command, :args)


### PR DESCRIPTION
This changes the daemon to ping redis when it starts. This is a
friendly feature to let a user know either their redis config is
wrong or redis is down. Without this, the process will start but
it will continuously error trying to connect to redis.

@kellyredding - Ready for review.
