### PR TITLE
Restart daemon if its thread shuts down unexpectantly

### DIFF
--- a/bench/report.txt
+++ b/bench/report.txt
@@ -5,7 +5,7 @@ Adding jobs
 Running jobs
 ....................................................................................................
 
-Adding 10000 Jobs Time:   1.6155s
-Running 10000 Jobs Time: 12.4848s
+Adding 10000 Jobs Time:   1.6133s
+Running 10000 Jobs Time: 12.4769s
 
 Done running benchmark report

--- a/lib/qs/daemon.rb
+++ b/lib/qs/daemon.rb
@@ -164,7 +164,8 @@ module Qs
 
       def wait_for_available_worker
         if !@worker_pool.worker_available? && @signal.start?
-          @worker_available_io.wait.read
+          @worker_available_io.wait
+          @worker_available_io.read
         end
       end
 

--- a/lib/qs/io_pipe.rb
+++ b/lib/qs/io_pipe.rb
@@ -31,9 +31,8 @@ module Qs
       @writer.write_nonblock(value[0, NUMBER_OF_BYTES])
     end
 
-    def wait
-      ::IO.select([@reader])
-      self
+    def wait(timeout = nil)
+      !!::IO.select([@reader], nil, nil, timeout)
     end
 
   end


### PR DESCRIPTION
This updates the `Process` to restart its `Daemon` if the daemon
stops unexpectantly. There is a small chance this could happen
since all redis errors are rescued already but its possible for
the daemon thread to crash and the process will keep running. This
changes it so the process periodically checks in on the daemon as
its listening for signals, if the daemon is no longer running, then
the process restarts it. This avoids the strange case where the
process is running but its not running any jobs because the daemon
has stopped but the `Process` is still waiting for signals.

@kellyredding - Ready for review. I noticed this over the weekend while I was messing with some stuff, but like I mentioned, it's a really minor case but I like it. Most likely, if the daemon is crashing its because I broke something while changing Qs. If we don't like restarting the daemon, the other option is to have the process just exit out if it sees its daemon crashed.