### PR TITLE
Add `Event`

### DIFF
--- a/lib/qs/event.rb
+++ b/lib/qs/event.rb
@@ -1,0 +1,80 @@
+require 'qs/job'
+
+module Qs
+
+  class Event
+
+    def self.build(channel, name, params, published_at = nil)
+      job_name   = Event::JobName.new(channel, name)
+      job_params = {
+        'event_channel' => channel,
+        'event_name'    => name,
+        'event_params'  => params
+      }
+      self.new(Qs::Job.new(job_name, job_params, published_at))
+    end
+
+    attr_reader :job
+
+    def initialize(job)
+      validate!(job)
+      @job = job
+    end
+
+    def channel
+      @job.params['event_channel']
+    end
+
+    def name
+      @job.params['event_name']
+    end
+
+    def params
+      @job.params['event_params']
+    end
+
+    def published_at
+      @job.created_at
+    end
+
+    def inspect
+      reference = '0x0%x' % (self.object_id << 1)
+      "#<#{self.class}:#{reference} " \
+      "@channel=#{self.channel.inspect} " \
+      "@name=#{self.name.inspect} " \
+      "@params=#{self.params.inspect} " \
+      "@published_at=#{self.published_at.inspect}>"
+    end
+
+    def ==(other)
+      if other.kind_of?(self.class)
+        self.job == other.job
+      else
+        super
+      end
+    end
+
+    private
+
+    def validate!(job)
+      problem = if job.params['event_channel'].to_s.empty?
+        "The job doesn't have an event channel."
+      elsif job.params['event_name'].to_s.empty?
+        "The job doesn't have an event name."
+      elsif !job.params['event_params'].kind_of?(::Hash)
+        "The job's event params are not valid."
+      end
+      raise(BadEventError, problem) if problem
+    end
+
+    module JobName
+      def self.new(event_channel, event_name)
+        "#{event_channel}:#{event_name}"
+      end
+    end
+
+  end
+
+  BadEventError = Class.new(ArgumentError)
+
+end

--- a/test/unit/event_tests.rb
+++ b/test/unit/event_tests.rb
@@ -1,0 +1,118 @@
+require 'assert'
+require 'qs/event'
+
+require 'qs/job'
+
+class Qs::Event
+
+  class UnitTests < Assert::Context
+    desc "Qs::Event"
+    setup do
+      @channel      = Factory.string
+      @name         = Factory.string
+      @params       = { Factory.string => Factory.string }
+      @published_at = Factory.time
+
+      @event_class = Qs::Event
+    end
+    subject{ @event_class }
+
+    should have_imeths :build
+
+    should "build an event from args" do
+      event = subject.build(@channel, @name, @params, @published_at)
+      job = event.job
+
+      assert_instance_of Qs::Job, job
+      assert_equal Qs::Event::JobName.new(@channel, @name), job.name
+      exp = {
+        'event_channel' => @channel,
+        'event_name'    => @name,
+        'event_params'  => @params
+      }
+      assert_equal exp, job.params
+      assert_equal @published_at, job.created_at
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @job_params = {
+        'event_channel' => @channel,
+        'event_name'    => @name,
+        'event_params'  => @params
+      }
+      @job = Qs::Job.new(Factory.string, @job_params)
+
+      @event = @event_class.new(@job)
+    end
+    subject{ @event }
+
+    should have_readers :job
+    should have_imeths :channel, :name, :params, :published_at
+
+    should "know its job" do
+      assert_equal @job, subject.job
+    end
+
+    should "know its channel, name, params and published at" do
+      assert_equal @job.params['event_channel'], subject.channel
+      assert_equal @job.params['event_name'],    subject.name
+      assert_equal @job.params['event_params'],  subject.params
+      assert_equal @job.created_at,              subject.published_at
+    end
+
+    should "raise an error when given an invalid job" do
+      job_params = @job_params.dup
+      job_params.delete('event_channel')
+      job = Qs::Job.new(Factory.string, job_params)
+      assert_raises(Qs::BadEventError){ @event_class.new(job) }
+
+      job_params = @job_params.dup
+      job_params.delete('event_name')
+      job = Qs::Job.new(Factory.string, job_params)
+      assert_raises(Qs::BadEventError){ @event_class.new(job) }
+
+      job_params = @job_params.dup
+      job_params.delete('event_params')
+      job = Qs::Job.new(Factory.string, job_params)
+      assert_raises(Qs::BadEventError){ @event_class.new(job) }
+    end
+
+    should "have a custom inspect" do
+      reference = '0x0%x' % (subject.object_id << 1)
+      expected = "#<Qs::Event:#{reference} " \
+                 "@channel=#{subject.channel.inspect} " \
+                 "@name=#{subject.name.inspect} " \
+                 "@params=#{subject.params.inspect} " \
+                 "@published_at=#{subject.published_at.inspect}>"
+      assert_equal expected, subject.inspect
+    end
+
+    should "be comparable" do
+      other_job   = Qs::Job.new(Factory.string, @job_params)
+      other_event = @event_class.new(other_job)
+
+      Assert.stub(other_job, :==).with(subject.job){ true }
+      assert_equal other_event, subject
+      Assert.stub(other_job, :==).with(subject.job){ false }
+      assert_not_equal other_event, subject
+    end
+
+  end
+
+  class JobNameTests < UnitTests
+    desc "JobName"
+    subject{ JobName }
+
+    should have_imeths :new
+
+    should "return an event job name given an event channel and event name" do
+      assert_equal "#{@channel}:#{@name}", subject.new(@channel, @name)
+    end
+
+  end
+
+end


### PR DESCRIPTION
This adds an `Event` object that is built from a job. This will be
used to support events in Qs, both when publishing events and when
processing them. An event composes a job. This is because events are
just special types of jobs and need to make use of a jobs logic.

When publishing an event, an `Event` instance will be built. Since
an `Event` composes a job, publishing the event is as simple as
enqueueing the events job on the dispatchers queue.

Similarly, when processing a job that represents an event, all
the existing logic can be reused because its a job. When an
event handler is built to process the event job, it will use the
job to build an `Event` instance, allowing access to its special
behavior.

This also adds an `Event::JobName` module that will be used to
build event job names when publishing events (via `Event.build`)
and when configuring events on a queue. These need to match up to
ensure events are correctly routed when being processed.

All of this provides the base to implement an events system in Qs
without reworking the existing system and how it handles jobs.

@kellyredding - Ready for review.