### PR TITLE
Add `EventHandler` mixin

### DIFF
--- a/lib/qs/event_handler.rb
+++ b/lib/qs/event_handler.rb
@@ -1,0 +1,38 @@
+require 'qs/event'
+require 'qs/job_handler'
+
+module Qs
+
+  module EventHandler
+
+    def self.included(klass)
+      klass.class_eval do
+        include Qs::JobHandler
+        include InstanceMethods
+      end
+    end
+
+    module InstanceMethods
+
+      def initialize(*args)
+        super
+        @qs_event = Event.new(@qs_runner.job)
+      end
+
+      def inspect
+        reference = '0x0%x' % (self.object_id << 1)
+        "#<#{self.class}:#{reference} @event=#{event.inspect}>"
+      end
+
+      private
+
+      # Helpers
+
+      def event;  @qs_event;        end
+      def params; @qs_event.params; end
+
+    end
+
+  end
+
+end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,4 +1,6 @@
 require 'assert/factory'
+require 'qs/job'
+require 'qs/event'
 
 module Factory
   extend Assert::Factory
@@ -9,6 +11,21 @@ module Factory
     exception = nil
     begin; raise(klass, message); rescue StandardError => exception; end
     exception
+  end
+
+  def self.job(params = nil)
+    name       = Factory.string
+    params     = { Factory.string => Factory.string }
+    created_at = Factory.time
+    Qs::Job.new(name, params, created_at)
+  end
+
+  def self.event_job(params = nil)
+    channel      = Factory.string
+    event        = Factory.string
+    params       = { Factory.string => Factory.string }
+    published_at = Factory.time
+    Qs::Event.build(channel, event, params, published_at).job
   end
 
 end

--- a/test/unit/event_handler_tests.rb
+++ b/test/unit/event_handler_tests.rb
@@ -1,0 +1,60 @@
+require 'assert'
+require 'qs/event_handler'
+
+require 'qs/event'
+require 'qs/job_handler'
+
+module Qs::EventHandler
+
+  class UnitTests < Assert::Context
+    desc "Qs::EventHandler"
+    setup do
+      @handler_class = Class.new{ include Qs::EventHandler }
+    end
+    subject{ @handler_class }
+
+    should "be a job handler" do
+      assert_includes Qs::JobHandler, subject
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @runner  = FakeRunner.new
+      @handler = TestEventHandler.new(@runner)
+    end
+    subject{ @handler }
+
+    should "know its event and params" do
+      event = Qs::Event.new(@runner.job)
+      assert_equal event,        subject.public_event
+      assert_equal event.params, subject.public_params
+    end
+
+    should "have a custom inspect" do
+      reference = '0x0%x' % (subject.object_id << 1)
+      expected = "#<#{subject.class}:#{reference} " \
+                 "@event=#{@handler.public_event.inspect}>"
+      assert_equal expected, subject.inspect
+    end
+
+  end
+
+  class TestEventHandler
+    include Qs::EventHandler
+
+    def public_params; params; end
+    def public_event;  event;  end
+  end
+
+  class FakeRunner
+    attr_accessor :job
+
+    def initialize
+      @job = Factory.event_job
+    end
+  end
+
+end

--- a/test/unit/job_handler_tests.rb
+++ b/test/unit/job_handler_tests.rb
@@ -181,7 +181,7 @@ module Qs::JobHandler
     should "have a custom inspect" do
       reference = '0x0%x' % (subject.object_id << 1)
       expected = "#<#{subject.class}:#{reference} " \
-                 "@job=#{@runner.job.inspect}>"
+                 "@job=#{@handler.public_job.inspect}>"
       assert_equal expected, subject.inspect
     end
 
@@ -220,17 +220,9 @@ module Qs::JobHandler
       @run_call_order = next_call_order
     end
 
-    def public_job
-      job
-    end
-
-    def public_params
-      params
-    end
-
-    def public_logger
-      logger
-    end
+    def public_job;    job;    end
+    def public_params; params; end
+    def public_logger; logger; end
 
     private
 
@@ -244,7 +236,7 @@ module Qs::JobHandler
     attr_accessor :job, :params, :logger
 
     def initialize
-      @job = Factory.string
+      @job    = Factory.job
       @params = Factory.string
       @logger = Factory.string
     end


### PR DESCRIPTION
This adds an `EventHandler` mixin for defining handlers for
processing an event. This is part of setting up an events system
in Qs.

The event handler extends the job handler functionality and uses
the job from its runner to build an `Event`. The params method
on an event handler returns its event params not the job params.
The event handler also provides access to the event itself similar
to how the job handler provides access to the job.

@kellyredding - Ready for review.