### PR TITLE
Add payload type to jobs

### DIFF
--- a/bench/report.txt
+++ b/bench/report.txt
@@ -5,7 +5,7 @@ Adding jobs
 Running jobs
 ....................................................................................................
 
-Adding 10000 Jobs Time:   1.4031s
-Running 10000 Jobs Time: 11.4099s
+Adding 10000 Jobs Time:   1.4578s
+Running 10000 Jobs Time: 11.5084s
 
 Done running benchmark report

--- a/lib/qs/daemon_data.rb
+++ b/lib/qs/daemon_data.rb
@@ -29,8 +29,8 @@ module Qs
       @routes           = build_routes(args[:routes] || [])
     end
 
-    def route_for(name)
-      @routes[name] || raise(NotFoundError, "no service named '#{name}'")
+    def route_for(route_name)
+      @routes[route_name] || raise(NotFoundError, "no job named '#{route_name}'")
     end
 
     private

--- a/lib/qs/event.rb
+++ b/lib/qs/event.rb
@@ -11,7 +11,9 @@ module Qs
         'event_name'    => name,
         'event_params'  => params
       }
-      self.new(Qs::Job.new(job_name, job_params, published_at))
+      self.new(Qs::Job.new(job_name, job_params, {
+        :created_at => published_at
+      }))
     end
 
     attr_reader :job

--- a/lib/qs/payload_handler.rb
+++ b/lib/qs/payload_handler.rb
@@ -38,7 +38,7 @@ module Qs
       log_job(job)
       redis_item.job = job
 
-      route = daemon_data.route_for(job.name)
+      route = daemon_data.route_for(job.route_name)
       log_handler_class(route.handler_class)
       redis_item.handler_class = route.handler_class
 

--- a/lib/qs/queue.rb
+++ b/lib/qs/queue.rb
@@ -33,7 +33,8 @@ module Qs
         handler_name = "#{self.job_handler_ns}::#{handler_name}"
       end
 
-      @routes.push(Qs::Route.new(name, handler_name))
+      route_name = Qs::Job::RouteName.new(Qs::Job::PAYLOAD_TYPE, name)
+      @routes.push(Qs::Route.new(route_name, handler_name))
     end
 
     def enqueue(job_name, params = nil)

--- a/lib/qs/route.rb
+++ b/lib/qs/route.rb
@@ -6,8 +6,8 @@ module Qs
 
     attr_reader :name, :handler_class_name, :handler_class
 
-    def initialize(name, handler_class_name)
-      @name = name.to_s
+    def initialize(job_route_name, handler_class_name)
+      @name = job_route_name.to_s
       @handler_class_name = handler_class_name
       @handler_class = nil
     end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -17,7 +17,7 @@ module Factory
     name       = Factory.string
     params     = { Factory.string => Factory.string }
     created_at = Factory.time
-    Qs::Job.new(name, params, created_at)
+    Qs::Job.new(name, params, :created_at => created_at)
   end
 
   def self.event_job(params = nil)

--- a/test/unit/job_tests.rb
+++ b/test/unit/job_tests.rb
@@ -6,9 +6,10 @@ class Qs::Job
   class UnitTests < Assert::Context
     desc "Qs::Job"
     setup do
-      @name       = Factory.string
-      @params     = { Factory.string => Factory.string }
-      @created_at = Factory.time
+      @payload_type = Factory.string
+      @name         = Factory.string
+      @params       = { Factory.string => Factory.string }
+      @created_at   = Factory.time
 
       @job_class = Qs::Job
     end
@@ -16,14 +17,20 @@ class Qs::Job
 
     should have_imeths :parse
 
+    should "know its payload type" do
+      assert_equal 'job', PAYLOAD_TYPE
+    end
+
     should "parse a job from a payload hash" do
       payload = {
+        'type'       => @payload_type,
         'name'       => @name,
         'params'     => @params,
         'created_at' => @created_at.to_i
       }
       job = subject.parse(payload)
       assert_instance_of subject, job
+      assert_equal payload['type'], job.payload_type
       assert_equal payload['name'], job.name
       assert_equal payload['params'], job.params
       assert_equal Time.at(payload['created_at']), job.created_at
@@ -37,44 +44,51 @@ class Qs::Job
       @current_time = Factory.time
       Assert.stub(Time, :now).with{ @current_time }
 
-      @job = @job_class.new(@name, @params, @created_at)
+      @job = @job_class.new(@name, @params, {
+        :type       => @payload_type,
+        :created_at => @created_at
+      })
     end
     subject{ @job }
 
-    should have_readers :name, :params, :created_at
-    should have_imeths :to_payload
+    should have_readers :payload_type, :name, :params, :created_at
+    should have_imeths :route_name, :to_payload
 
-    should "know its name, params and created at" do
-      assert_equal @name,       subject.name
-      assert_equal @params,     subject.params
-      assert_equal @created_at, subject.created_at
+    should "know its payload type, name, params and created at" do
+      assert_equal @payload_type, subject.payload_type
+      assert_equal @name,         subject.name
+      assert_equal @params,       subject.params
+      assert_equal @created_at,   subject.created_at
     end
 
-    should "default its created at" do
+    should "default its payload type and created at" do
       job = @job_class.new(@name, @params)
+      assert_equal PAYLOAD_TYPE,  job.payload_type
       assert_equal @current_time, job.created_at
     end
 
     should "return a payload hash using `to_payload`" do
-      payload_hash = subject.to_payload
-      expected = {
+      exp = {
+        'type'       => @payload_type,
         'name'       => @name,
         'params'     => @params,
         'created_at' => @created_at.to_i
       }
-      assert_equal expected, payload_hash
+      assert_equal exp, subject.to_payload
     end
 
-    should "convert job names to strings using `to_payload`" do
-      job = @job_class.new(@name.to_sym, @params)
-      assert_equal @name, job.to_payload['name']
-    end
-
-    should "convert stringify its params using `to_payload`" do
+    should "sanitize its attributes with `to_payload`" do
       params = { Factory.string.to_sym => Factory.string }
-      job = @job_class.new(@name, params)
+      payload = @job_class.new(@name.to_sym, params, {
+        :type       => @payload_type.to_sym,
+        :created_at => @created_at
+      }).to_payload
+
+      assert_equal @payload_type, payload['type']
+      assert_equal @name, payload['name']
       exp = StringifyParams.new(params)
-      assert_equal exp, job.to_payload['params']
+      assert_equal exp, payload['params']
+      assert_equal @created_at.to_i, payload['created_at']
     end
 
     should "raise an error when given an invalid name or params" do
@@ -85,23 +99,32 @@ class Qs::Job
 
     should "have a custom inspect" do
       reference = '0x0%x' % (subject.object_id << 1)
-      expected = "#<Qs::Job:#{reference} " \
-                 "@name=#{subject.name.inspect} " \
-                 "@params=#{subject.params.inspect} " \
-                 "@created_at=#{subject.created_at.inspect}>"
-      assert_equal expected, subject.inspect
+      exp = "#<Qs::Job:#{reference} " \
+            "@name=#{subject.name.inspect} " \
+            "@params=#{subject.params.inspect} " \
+            "@created_at=#{subject.created_at.inspect}>"
+      assert_equal exp, subject.inspect
     end
 
     should "be comparable" do
-      matching = @job_class.new(@name, @params, @created_at)
-      assert_equal matching, subject
-      non_matching = @job_class.new(Factory.string, @params, @created_at)
-      assert_not_equal non_matching, subject
-      params = { Factory.string => Factory.string }
-      non_matching = @job_class.new(@name, params, @created_at)
-      assert_not_equal non_matching, subject
-      non_matching = @job_class.new(@name, @params, Factory.time)
-      assert_not_equal non_matching, subject
+      other_job = @job_class.new(@name, @params)
+      Assert.stub(other_job, :to_payload){ subject.to_payload }
+      assert_equal other_job, subject
+      Assert.stub(other_job, :to_payload){ Hash.new }
+      assert_not_equal other_job, subject
+    end
+
+  end
+
+  class RouteNameTests < UnitTests
+    desc "RouteName"
+    subject{ RouteName }
+
+    should have_imeths :new
+
+    should "build a route name given a payload type and name" do
+      exp = "#{@payload_type}|#{@name}"
+      assert_equal exp, RouteName.new(@payload_type, @name)
     end
 
   end

--- a/test/unit/payload_handler_tests.rb
+++ b/test/unit/payload_handler_tests.rb
@@ -20,12 +20,12 @@ class Qs::PayloadHandler
   class InitTests < UnitTests
     desc "when init"
     setup do
-      @route_spy = RouteSpy.new
+      @job = Factory.job
+      @route_spy = RouteSpy.new(@job.route_name)
       @daemon_data = Qs::DaemonData.new({
         :logger => Qs::NullLogger.new,
         :routes => [@route_spy]
       })
-      @job = Qs::Job.new(@route_spy.name, Factory.string => Factory.string)
       serialized_payload = Qs.serialize(@job.to_payload)
       @redis_item = Qs::RedisItem.new(Factory.string, serialized_payload)
 
@@ -214,8 +214,8 @@ class Qs::PayloadHandler
     attr_reader :job_passed_to_run, :daemon_data_passed_to_run
     attr_reader :run_called
 
-    def initialize
-      @name = Factory.string
+    def initialize(job_route_name)
+      @name = job_route_name
       @job_passed_to_run = nil
       @daemon_data_passed_to_run = nil
       @run_called = false

--- a/test/unit/queue_tests.rb
+++ b/test/unit/queue_tests.rb
@@ -8,9 +8,7 @@ class Qs::Queue
   class UnitTests < Assert::Context
     desc "Qs::Queue"
     setup do
-      @queue = Qs::Queue.new do
-        name Factory.string
-      end
+      @queue = Qs::Queue.new{ name Factory.string }
     end
     subject{ @queue }
 
@@ -56,7 +54,8 @@ class Qs::Queue
 
       route = subject.routes.last
       assert_instance_of Qs::Route, route
-      assert_equal job_name, route.name
+      exp = Qs::Job::RouteName.new(Qs::Job::PAYLOAD_TYPE, job_name)
+      assert_equal exp, route.name
       assert_equal handler_name, route.handler_class_name
     end
 


### PR DESCRIPTION
This updates jobs to know a payload type. This is setup for
supporting events in the system. Specifically, this ensures that
there won't be any collisions when routing jobs and events. With
the previous setup, it would be possible to craft a job/event
combo such that they resulted having the same job name. This would
cause them to not be routed correctly.

This fixes the problem by providing a payload type. Jobs will set
this to "job" and events will set it to "event". When routing the
payload type will be prefixed to the name. This ensures that no
matter what, jobs/events will be routed separately and not collide.

To support this, the `Queue` must also build the prefixed job name
for its routes when they are configured.

@kellyredding - Ready for review. There's a slowdown with doing this change, which is expected. We are adding more data to the payload (more to serialize/deserialize) and having to build a route name (concat a string) in addition to what was previously being done.