### PR TITLE
Split `TestHelpers`, one for `JobHandler` and one for `EventHandler`

### DIFF
--- a/lib/qs/event_handler_test_helpers.rb
+++ b/lib/qs/event_handler_test_helpers.rb
@@ -1,0 +1,17 @@
+require 'qs/job_test_runner'
+
+module Qs::EventHandler
+
+  module TestHelpers
+
+    def test_runner(handler_class, args = nil)
+      Qs::EventTestRunner.new(handler_class, args)
+    end
+
+    def test_handler(handler_class, args = nil)
+      test_runner(handler_class, args).handler
+    end
+
+  end
+
+end

--- a/lib/qs/job_handler_test_helpers.rb
+++ b/lib/qs/job_handler_test_helpers.rb
@@ -1,11 +1,11 @@
-require 'qs/test_runner'
+require 'qs/job_test_runner'
 
-module Qs
+module Qs::JobHandler
 
   module TestHelpers
 
     def test_runner(handler_class, args = nil)
-      TestRunner.new(handler_class, args)
+      Qs::JobTestRunner.new(handler_class, args)
     end
 
     def test_handler(handler_class, args = nil)

--- a/lib/qs/runner.rb
+++ b/lib/qs/runner.rb
@@ -9,12 +9,13 @@ module Qs
 
     def initialize(handler_class, args = nil)
       @handler_class = handler_class
-      @handler = @handler_class.new(self)
 
       a = args || {}
       @job    = a[:job]
       @params = a[:params] || {}
       @logger = a[:logger] || Qs::NullLogger.new
+
+      @handler = @handler_class.new(self)
     end
 
     def run

--- a/test/unit/job_handler_test_helper_tests.rb
+++ b/test/unit/job_handler_test_helper_tests.rb
@@ -1,0 +1,55 @@
+require 'assert'
+require 'qs/job_handler_test_helpers'
+
+require 'qs/job_handler'
+require 'qs/job_test_runner'
+require 'test/support/runner_spy'
+
+module Qs::JobHandler::TestHelpers
+
+  class UnitTests < Assert::Context
+    desc "Qs::TestHelpers"
+    setup do
+      @test_helpers = Qs::JobHandler::TestHelpers
+    end
+    subject{ @test_helpers }
+
+  end
+
+  class MixinTests < UnitTests
+    desc "as a mixin"
+    setup do
+      @handler_class = Class.new
+      @args = { Factory.string => Factory.string }
+
+      @runner_spy = nil
+      Assert.stub(Qs::JobTestRunner, :new) do |*args|
+        @runner_spy = RunnerSpy.new(*args)
+      end
+
+      context_class = Class.new{ include Qs::JobHandler::TestHelpers }
+      @context = context_class.new
+    end
+    subject{ @context }
+
+    should have_imeths :test_runner, :test_handler
+
+    should "build a job test runner for a given handler using `test_runner`" do
+      result = subject.test_runner(@handler_class, @args)
+
+      assert_not_nil @runner_spy
+      assert_equal @handler_class, @runner_spy.handler_class
+      assert_equal @args, @runner_spy.args
+      assert_equal @runner_spy, result
+    end
+
+    should "return an initialized handler instance using `test_handler`" do
+      result = subject.test_handler(@handler_class, @args)
+
+      assert_not_nil @runner_spy
+      assert_equal @runner_spy.handler, result
+    end
+
+  end
+
+end


### PR DESCRIPTION
This splits the test helpers into two mixins, one for `JobHandler`
and one for `EventHandler`. This is so each can provide a different
`test_runner` method and in general, different test helpers as
needed.

This renames the `TestRunner` to `JobTestRunner` and adds an
`EventTestRunner` that inherits from it. The `EventTestRunner`
checks that its passed an `EventHandler` and also sets up passing
an event job. `EventHandler`, unlike `JobHandler`, requires its
runner to have an event job. To handle this, the `EventTestRunner`
will build an event job and super it to the `TestRunner`. It also
handles params so it can easily be passed event params directly.

This also fixes a minor issue with how the `Runner` set its
attributes and built its handler. Since event handlers require
their runner to have an event job when they are built, the base
`Runner` needs to set its attributes before it builds an instance
of the handler.

@kellyredding - Ready for review.