### PR TITLE
Update `Event` to set a custom payload type

### DIFF
--- a/lib/qs/event.rb
+++ b/lib/qs/event.rb
@@ -4,7 +4,10 @@ module Qs
 
   class Event
 
-    def self.build(channel, name, params, published_at = nil)
+    PAYLOAD_TYPE = 'event'
+
+    def self.build(channel, name, params, options = nil)
+      options ||= {}
       job_name   = Event::JobName.new(channel, name)
       job_params = {
         'event_channel' => channel,
@@ -12,7 +15,8 @@ module Qs
         'event_params'  => params
       }
       self.new(Qs::Job.new(job_name, job_params, {
-        :created_at => published_at
+        :type       => PAYLOAD_TYPE,
+        :created_at => options[:published_at]
       }))
     end
 

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -25,7 +25,7 @@ module Factory
     event        = Factory.string
     params       = { Factory.string => Factory.string }
     published_at = Factory.time
-    Qs::Event.build(channel, event, params, published_at).job
+    Qs::Event.build(channel, event, params, :published_at => published_at).job
   end
 
 end

--- a/test/unit/event_tests.rb
+++ b/test/unit/event_tests.rb
@@ -19,11 +19,18 @@ class Qs::Event
 
     should have_imeths :build
 
+    should "know its payload type" do
+      assert_equal 'event', PAYLOAD_TYPE
+    end
+
     should "build an event from args" do
-      event = subject.build(@channel, @name, @params, @published_at)
+      event = subject.build(@channel, @name, @params, {
+        :published_at => @published_at
+      })
       job = event.job
 
       assert_instance_of Qs::Job, job
+      assert_equal PAYLOAD_TYPE, job.payload_type
       assert_equal Qs::Event::JobName.new(@channel, @name), job.name
       exp = {
         'event_channel' => @channel,


### PR DESCRIPTION
This updates event to set a custom payload type when it builds a
job. This is part of supporting events and avoiding routing issues
with jobs. By always settings its payload type to something
different its not possible for a job and event job to have the
same route name.

This also changes the `Event.build` method to take an options hash
on the end instead of its published at timestamp. This is to give
it a consistent feel as `Job` which now takes an options hash. This
doesn't change any of the functionality, just the interface.

@kellyredding - Ready for review.