### PR TITLE
Add `Qs.publish`

### DIFF
--- a/lib/qs.rb
+++ b/lib/qs.rb
@@ -45,6 +45,10 @@ module Qs
     @client.enqueue(queue, job_name, params)
   end
 
+  def self.publish(channel, name, params = nil)
+    @client.publish(channel, name, params)
+  end
+
   def self.push(queue_name, payload)
     @client.push(queue_name, payload)
   end
@@ -75,6 +79,10 @@ module Qs
 
   def self.dispatcher_job_name
     self.config.dispatcher_job_name
+  end
+
+  def self.published_events
+    self.dispatcher_queue.published_events
   end
 
   class Config

--- a/lib/qs/client.rb
+++ b/lib/qs/client.rb
@@ -1,5 +1,6 @@
 require 'hella-redis'
 require 'qs'
+require 'qs/dispatch_job'
 require 'qs/job'
 require 'qs/queue'
 
@@ -33,6 +34,12 @@ module Qs
         job = Qs::Job.new(job_name, params || {})
         enqueue!(queue, job)
         job
+      end
+
+      def publish(channel, name, params = nil)
+        dispatch_job = DispatchJob.new(channel, name, params || {})
+        enqueue!(Qs.dispatcher_queue, dispatch_job)
+        dispatch_job.event
       end
 
       def push(queue_name, payload)

--- a/lib/qs/dispatch_job.rb
+++ b/lib/qs/dispatch_job.rb
@@ -1,0 +1,29 @@
+require 'qs'
+require 'qs/event'
+require 'qs/job'
+
+module Qs
+
+  class DispatchJob < Qs::Job
+
+    def initialize(event_channel, event_name, event_params, options = nil)
+      params = {
+        'event_channel' => event_channel,
+        'event_name'    => event_name,
+        'event_params'  => event_params
+      }
+      super(Qs.dispatcher_job_name, params, options)
+    end
+
+    def event
+      @event ||= Qs::Event.build(
+        params['event_channel'],
+        params['event_name'],
+        params['event_params'],
+        { :published_at => self.created_at }
+      )
+    end
+
+  end
+
+end

--- a/lib/qs/queue.rb
+++ b/lib/qs/queue.rb
@@ -42,6 +42,10 @@ module Qs
     end
     alias :add :enqueue
 
+    def published_events
+      self.enqueued_jobs.map(&:event)
+    end
+
     def reset!
       self.enqueued_jobs.clear
     end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -14,18 +14,43 @@ module Factory
   end
 
   def self.job(params = nil)
-    name       = Factory.string
-    params     = { Factory.string => Factory.string }
-    created_at = Factory.time
-    Qs::Job.new(name, params, :created_at => created_at)
+    params ||= {}
+    params[:name]       ||= Factory.string
+    params[:params]     ||= { Factory.string => Factory.string }
+    params[:created_at] ||= Factory.time
+    Qs::Job.new(
+      params.delete(:name),
+      params.delete(:params),
+      params
+    )
+  end
+
+  def self.dispatch_job(params = nil)
+    params ||= {}
+    params[:event_channel] ||= Factory.string
+    params[:event_name]    ||= Factory.string
+    params[:event_params]  ||= { Factory.string => Factory.string }
+    params[:created_at]    ||= Factory.time
+    Qs::DispatchJob.new(
+      params.delete(:event_channel),
+      params.delete(:event_name),
+      params.delete(:event_params),
+      params
+    )
   end
 
   def self.event_job(params = nil)
-    channel      = Factory.string
-    event        = Factory.string
-    params       = { Factory.string => Factory.string }
-    published_at = Factory.time
-    Qs::Event.build(channel, event, params, :published_at => published_at).job
+    params ||= {}
+    params[:channel]      ||= Factory.string
+    params[:name]         ||= Factory.string
+    params[:params]       ||= { Factory.string => Factory.string }
+    params[:published_at] ||= Factory.time
+    Qs::Event.build(
+      params.delete(:channel),
+      params.delete(:name),
+      params.delete(:params),
+      params
+    ).job
   end
 
 end

--- a/test/unit/dispatch_job_tests.rb
+++ b/test/unit/dispatch_job_tests.rb
@@ -1,0 +1,62 @@
+require 'assert'
+require 'qs/dispatch_job'
+
+require 'qs/event'
+require 'qs/job'
+
+class Qs::DispatchJob
+
+  class UnitTests < Assert::Context
+    desc "Qs::DispatchJob"
+    setup do
+      @job_class = Qs::DispatchJob
+    end
+    subject{ @job_class }
+
+    should "be a job" do
+      assert Qs::DispatchJob < Qs::Job
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @event_channel = Factory.string
+      @event_name    = Factory.string
+      @event_params  = { Factory.string => Factory.string }
+      @created_at    = Factory.time
+      @job = @job_class.new(@event_channel, @event_name, @event_params, {
+        :created_at => @created_at
+      })
+    end
+    subject{ @job }
+
+    should have_imeths :event
+
+    should "know its name, params and created at" do
+      assert_equal Qs.dispatcher_job_name, subject.name
+      exp = {
+        'event_channel' => @event_channel,
+        'event_name'    => @event_name,
+        'event_params'  => @event_params
+      }
+      assert_equal exp, subject.params
+      assert_equal @created_at, subject.created_at
+    end
+
+    should "know how to build an event from its params" do
+      event = subject.event
+      exp = Qs::Event.build(
+        @event_channel,
+        @event_name,
+        @event_params,
+        { :published_at => @created_at }
+      )
+      assert_equal exp, event
+      assert_same event, subject.event
+    end
+
+  end
+
+end


### PR DESCRIPTION
This adds the ability to publish events using Qs. This creates a
dispatch job and adds it to the configured dispatcher queue. This
will allow the dispatcher to find subscriptions for the event and
add event jobs to each of the subscribed queues.

This also adds `published_events` to Qs. This is a test helper for
checking what events have been published. The `TestClient` will
add dispatch jobs to the dispatcher queues enqueued jobs which
allows asking for event the dispatch job represents.

This also includes a few test cleanups. Job factories now allow
passing params so their values can be set to a specific value if
needed. This also updates the base `Client` enqueue tests to check
that it uses the queue that it is passed. This was accidentally
missed when it was originally developed.

@kellyredding - Ready for review.