### PR TITLE
Add `event` to `Queue`

### DIFF
--- a/lib/qs/queue.rb
+++ b/lib/qs/queue.rb
@@ -28,12 +28,27 @@ module Qs
       @job_handler_ns
     end
 
+    def event_handler_ns(value = nil)
+      @event_handler_ns = value if !value.nil?
+      @event_handler_ns
+    end
+
     def job(name, handler_name)
       if self.job_handler_ns && !(handler_name =~ /^::/)
         handler_name = "#{self.job_handler_ns}::#{handler_name}"
       end
 
       route_name = Qs::Job::RouteName.new(Qs::Job::PAYLOAD_TYPE, name)
+      @routes.push(Qs::Route.new(route_name, handler_name))
+    end
+
+    def event(channel, name, handler_name)
+      if self.event_handler_ns && !(handler_name =~ /^::/)
+        handler_name = "#{self.event_handler_ns}::#{handler_name}"
+      end
+
+      job_name   = Qs::Event::JobName.new(channel, name)
+      route_name = Qs::Job::RouteName.new(Qs::Event::PAYLOAD_TYPE, job_name)
       @routes.push(Qs::Route.new(route_name, handler_name))
     end
 
@@ -54,7 +69,8 @@ module Qs
       reference = '0x0%x' % (self.object_id << 1)
       "#<#{self.class}:#{reference} " \
         "@name=#{self.name.inspect} " \
-        "@job_handler_ns=#{self.job_handler_ns.inspect}>"
+        "@job_handler_ns=#{self.job_handler_ns.inspect} " \
+        "@event_handler_ns=#{self.event_handler_ns.inspect}>"
     end
 
     InvalidError = Class.new(RuntimeError)


### PR DESCRIPTION
This adds an `event` method to `Queue` for configuring what events
a queue listens for and can handle. This works similarly to the
`job` method, the only difference is it builds the job name using
the event channel and event name. This will allow an event job to
be routed to the configured handler correctly.

This also adds an `event_handler_ns` which functions the same as
the `job_handler_ns`. Event handler class names will be prefixed
with it if set.

Finally, this also includes an additional test to check that the
job handler ns is ignored for a top-level handler class name
(prefixed with `::`).

@kellyredding - Ready for review.