### PR TITLE
	Store queues as event subscribers in redis

### DIFF
--- a/lib/qs.rb
+++ b/lib/qs.rb
@@ -61,6 +61,14 @@ module Qs
     @deserializer.call(serialized_payload)
   end
 
+  def self.sync_subscriptions(queue)
+    self.client.sync_subscriptions(queue)
+  end
+
+  def self.clear_subscriptions(queue)
+    self.client.clear_subscriptions(queue)
+  end
+
   def self.client
     @client
   end

--- a/lib/qs/event.rb
+++ b/lib/qs/event.rb
@@ -79,6 +79,12 @@ module Qs
       end
     end
 
+    module SubscribersRedisKey
+      def self.new(event_job_name)
+        "events:#{event_job_name}:subscribers"
+      end
+    end
+
   end
 
   BadEventError = Class.new(ArgumentError)

--- a/qs.gemspec
+++ b/qs.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency("dat-worker-pool", ["~> 0.5"])
-  gem.add_dependency("hella-redis",     ["~> 0.2"])
+  gem.add_dependency("hella-redis",     ["~> 0.3"])
   gem.add_dependency("ns-options",      ["~> 1.1"])
   gem.add_dependency("SystemTimer",     ["~> 1.2"])
 

--- a/test/unit/event_tests.rb
+++ b/test/unit/event_tests.rb
@@ -122,4 +122,18 @@ class Qs::Event
 
   end
 
+  class SubscribersRedisKeyTests < UnitTests
+    desc "SubscribersRedisKey"
+    subject{ SubscribersRedisKey }
+
+    should have_imeths :new
+
+    should "return an event subscribers redis key given an event job name" do
+      event_job_name = JobName.new(@channel, @name)
+      exp = "events:#{event_job_name}:subscribers"
+      assert_equal exp, subject.new(event_job_name)
+    end
+
+  end
+
 end


### PR DESCRIPTION
This updates queues to store themselves as subscribers for their
events in redis. This is part of the events system. This will be
used by the dispatcher when it receives a dispatch job from an
event publish. The dispatcher will look at the events subscribers
and add an event job to each of them.

This adds 2 methods for managing the subscribers to `Client`:
`sync_subscriptions` and `clear_subscriptions`. These methods are
demetered on `Qs` and `Queue` for convenience.

The `sync_subscriptions` method takes a queue and for every event
configured on it, adds the queue name to the events subscribers in
redis. This allows the dispatcher to be aware of the events a
queue is subscribed to and add event jobs to it as needed. This
should be run anytime a queues configured events change.

The `clear_subscriptions` method takes a queue and tries to remove
it from all events subscribers in redis. This ensures that the
queue is no longer subscribed to any events and stops having event
jobs added to it. This should be used when a queue is no longer
being used.

@kellyredding - Ready for review. 