### PR TITLE
Add optional publisher for events

### DIFF
--- a/lib/qs.rb
+++ b/lib/qs.rb
@@ -49,6 +49,10 @@ module Qs
     @client.publish(channel, name, params)
   end
 
+  def self.publish_as(publisher, channel, name, params = nil)
+    @client.publish_as(publisher, channel, name, params)
+  end
+
   def self.push(queue_name, payload)
     @client.push(queue_name, payload)
   end
@@ -89,6 +93,10 @@ module Qs
     self.config.dispatcher_job_name
   end
 
+  def self.event_publisher
+    self.config.event_publisher
+  end
+
   def self.published_events
     self.dispatcher_queue.published_events
   end
@@ -98,6 +106,7 @@ module Qs
 
     option :dispatcher_name,     String, :default => 'dispatcher'
     option :dispatcher_job_name, String, :default => 'dispatch_event'
+    option :event_publisher,     String
 
     option :encoder, Proc, :default => proc{ |p| ::JSON.dump(p) }
     option :decoder, Proc, :default => proc{ |p| ::JSON.load(p) }

--- a/lib/qs/client.rb
+++ b/lib/qs/client.rb
@@ -38,9 +38,11 @@ module Qs
       end
 
       def publish(channel, name, params = nil)
-        dispatch_job = DispatchJob.new(channel, name, params || {})
-        enqueue!(Qs.dispatcher_queue, dispatch_job)
-        dispatch_job.event
+        publish!(channel, name, params)
+      end
+
+      def publish_as(publisher, channel, name, params = nil)
+        publish!(channel, name, params, :event_publisher => publisher)
       end
 
       def push(queue_name, payload)
@@ -86,6 +88,12 @@ module Qs
       end
 
       private
+
+      def publish!(channel, name, params = nil, options = nil)
+        dispatch_job = DispatchJob.new(channel, name, params || {}, options)
+        enqueue!(Qs.dispatcher_queue, dispatch_job)
+        dispatch_job.event
+      end
 
       def redis_transaction
         self.redis.with{ |c| c.pipelined{ c.multi{ yield c } } }

--- a/lib/qs/dispatch_job.rb
+++ b/lib/qs/dispatch_job.rb
@@ -7,10 +7,13 @@ module Qs
   class DispatchJob < Qs::Job
 
     def initialize(event_channel, event_name, event_params, options = nil)
+      options ||= {}
+      event_publisher = options.delete(:event_publisher) || Qs.event_publisher
       params = {
-        'event_channel' => event_channel,
-        'event_name'    => event_name,
-        'event_params'  => event_params
+        'event_channel'   => event_channel,
+        'event_name'      => event_name,
+        'event_params'    => event_params,
+        'event_publisher' => event_publisher
       }
       super(Qs.dispatcher_job_name, params, options)
     end
@@ -20,7 +23,9 @@ module Qs
         params['event_channel'],
         params['event_name'],
         params['event_params'],
-        { :published_at => self.created_at }
+        { :publisher    => params['event_publisher'],
+          :published_at => self.created_at
+        }
       )
     end
 

--- a/lib/qs/event.rb
+++ b/lib/qs/event.rb
@@ -6,13 +6,14 @@ module Qs
 
     PAYLOAD_TYPE = 'event'
 
-    attr_reader :channel, :name, :published_at
+    attr_reader :channel, :name, :publisher, :published_at
 
     def initialize(channel, name, params, options = nil)
       validate!(channel, name, params)
       options ||= {}
       @channel      = channel
       @name         = name
+      @publisher    = options[:publisher]
       @published_at = options[:published_at] || Time.now
       super(PAYLOAD_TYPE, params)
     end
@@ -27,6 +28,7 @@ module Qs
       "@channel=#{self.channel.inspect} " \
       "@name=#{self.name.inspect} " \
       "@params=#{self.params.inspect} " \
+      "@publisher=#{self.publisher.inspect} " \
       "@published_at=#{self.published_at.inspect}>"
     end
 
@@ -36,6 +38,7 @@ module Qs
         self.channel      == other.channel      &&
         self.name         == other.name         &&
         self.params       == other.params       &&
+        self.publisher    == other.publisher    &&
         self.published_at == other.published_at
       else
         super

--- a/lib/qs/payload.rb
+++ b/lib/qs/payload.rb
@@ -38,7 +38,8 @@ module Qs
         payload_hash['channel'],
         payload_hash['name'],
         payload_hash['params'],
-        { :published_at => Timestamp.to_time(payload_hash['published_at']) }
+        { :publisher    => payload_hash['publisher'],
+          :published_at => Timestamp.to_time(payload_hash['published_at']) }
       )
     end
 
@@ -46,6 +47,7 @@ module Qs
       self.message_hash(event, {
         'channel'      => event.channel.to_s,
         'name'         => event.name.to_s,
+        'publisher'    => event.publisher.to_s,
         'published_at' => Timestamp.new(event.published_at)
       })
     end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -49,6 +49,7 @@ module Factory
     params[:channel]      ||= Factory.string
     params[:name]         ||= Factory.string
     params[:params]       ||= { Factory.string => Factory.string }
+    params[:publisher]    ||= Factory.string
     params[:published_at] ||= Factory.time
     Qs::Event.new(
       params.delete(:channel),

--- a/test/unit/dispatch_job_tests.rb
+++ b/test/unit/dispatch_job_tests.rb
@@ -22,13 +22,18 @@ class Qs::DispatchJob
   class InitTests < UnitTests
     desc "when init"
     setup do
-      @event_channel = Factory.string
-      @event_name    = Factory.string
-      @event_params  = { Factory.string => Factory.string }
-      @created_at    = Factory.time
+      @event_channel   = Factory.string
+      @event_name      = Factory.string
+      @event_params    = { Factory.string => Factory.string }
+      @event_publisher = Factory.string
+      @created_at      = Factory.time
       @job = @job_class.new(@event_channel, @event_name, @event_params, {
-        :created_at => @created_at
+        :event_publisher => @event_publisher,
+        :created_at      => @created_at
       })
+    end
+    teardown do
+      Qs.reset!
     end
     subject{ @job }
 
@@ -37,12 +42,19 @@ class Qs::DispatchJob
     should "know its name, params and created at" do
       assert_equal Qs.dispatcher_job_name, subject.name
       exp = {
-        'event_channel' => @event_channel,
-        'event_name'    => @event_name,
-        'event_params'  => @event_params
+        'event_channel'   => @event_channel,
+        'event_name'      => @event_name,
+        'event_params'    => @event_params,
+        'event_publisher' => @event_publisher
       }
       assert_equal exp, subject.params
       assert_equal @created_at, subject.created_at
+    end
+
+    should "default its event publisher" do
+      Qs.config.event_publisher = Factory.string
+      job = @job_class.new(@event_channel, @event_name, @event_params)
+      assert_equal Qs.event_publisher, job.params['event_publisher']
     end
 
     should "know how to build an event from its params" do
@@ -51,7 +63,9 @@ class Qs::DispatchJob
         @event_channel,
         @event_name,
         @event_params,
-        { :published_at => @created_at }
+        { :publisher    => @event_publisher,
+          :published_at => @created_at
+        }
       )
       assert_equal exp, event
       assert_same event, subject.event

--- a/test/unit/event_tests.rb
+++ b/test/unit/event_tests.rb
@@ -11,6 +11,7 @@ class Qs::Event
       @channel      = Factory.string
       @name         = Factory.string
       @params       = { Factory.string => Factory.string }
+      @publisher    = Factory.string
       @published_at = Factory.time
 
       @event_class = Qs::Event
@@ -34,12 +35,13 @@ class Qs::Event
       Assert.stub(Time, :now).with{ @current_time }
 
       @event = @event_class.new(@channel, @name, @params, {
+        :publisher    => @publisher,
         :published_at => @published_at
       })
     end
     subject{ @event }
 
-    should have_readers :channel, :name, :published_at
+    should have_readers :channel, :name, :publisher, :published_at
     should have_imeths :route_name
 
     should "know its attributes" do
@@ -47,6 +49,7 @@ class Qs::Event
       assert_equal @channel,      subject.channel
       assert_equal @name,         subject.name
       assert_equal @params,       subject.params
+      assert_equal @publisher,    subject.publisher
       assert_equal @published_at, subject.published_at
     end
 
@@ -68,30 +71,41 @@ class Qs::Event
             "@channel=#{subject.channel.inspect} " \
             "@name=#{subject.name.inspect} " \
             "@params=#{subject.params.inspect} " \
+            "@publisher=#{subject.publisher.inspect} " \
             "@published_at=#{subject.published_at.inspect}>"
       assert_equal exp, subject.inspect
     end
 
     should "be comparable" do
       matching = @event_class.new(@channel, @name, @params, {
+        :publisher    => @publisher,
         :published_at => @published_at
       })
       assert_equal matching, subject
 
       non_matching = @event_class.new(Factory.string, @name, @params, {
+        :publisher    => @publisher,
         :published_at => @published_at
       })
       assert_not_equal non_matching, subject
       non_matching = @event_class.new(@channel, Factory.string, @params, {
+        :publisher    => @publisher,
         :published_at => @published_at
       })
       assert_not_equal non_matching, subject
       other_params = { Factory.string => Factory.string }
       non_matching = @event_class.new(@channel, @name, other_params, {
+        :publisher    => @publisher,
         :published_at => @published_at
       })
       assert_not_equal non_matching, subject
       non_matching = @event_class.new(@channel, @name, @params, {
+        :publisher    => Factory.string,
+        :published_at => @published_at
+      })
+      assert_not_equal non_matching, subject
+      non_matching = @event_class.new(@channel, @name, @params, {
+        :publisher    => @publisher,
         :published_at => Factory.time
       })
       assert_not_equal non_matching, subject

--- a/test/unit/payload_tests.rb
+++ b/test/unit/payload_tests.rb
@@ -57,6 +57,7 @@ module Qs::Payload
         'channel'      => event.channel,
         'name'         => event.name,
         'params'       => event.params,
+        'publisher'    => event.publisher,
         'published_at' => Timestamp.new(event.published_at)
       }
       assert_equal event, subject.event(payload_hash)
@@ -65,9 +66,10 @@ module Qs::Payload
 
     should "sanitize its events attributes when building an event payload hash" do
       event = Factory.event({
-        :channel => Factory.string.to_sym,
-        :name    => Factory.string.to_sym,
-        :params  => { Factory.string.to_sym => Factory.string }
+        :channel   => Factory.string.to_sym,
+        :name      => Factory.string.to_sym,
+        :params    => { Factory.string.to_sym => Factory.string },
+        :publisher => Factory.string.to_sym
       })
       payload_hash = subject.event_hash(event)
 
@@ -75,6 +77,7 @@ module Qs::Payload
       assert_equal event.name.to_s,    payload_hash['name']
       exp = StringifyParams.new(event.params)
       assert_equal exp, payload_hash['params']
+      assert_equal event.publisher.to_s, payload_hash['publisher']
     end
 
     should "raise errors for unknown parent types" do


### PR DESCRIPTION
This adds an optional publisher that can either be configured
globally or specified when publishing an event. This can be used
for tracking purposes and identifying where an event was published
from for debugging. There is now a `publish_as` method which can
be used to specify a publisher when publishing an event. This
method works the same as the `publish` method only it sets the
publisher.

@kellyredding - Ready for review.