### PR TITLE
Add `Payload` module for serializing and deserializing

### DIFF
--- a/lib/qs.rb
+++ b/lib/qs.rb
@@ -24,18 +24,18 @@ module Qs
       Queue.new{ name(dispatcher_name) }
     end
 
-    @serializer   ||= self.config.serializer
-    @deserializer ||= self.config.deserializer
-    @client       ||= Client.new(self.redis_config)
-    @redis        ||= @client.redis
+    @encoder ||= self.config.encoder
+    @decoder ||= self.config.decoder
+    @client  ||= Client.new(self.redis_config)
+    @redis   ||= @client.redis
     true
   end
 
   def self.reset!
     self.config.reset
     @dispatcher_queue = nil
-    @serializer       = nil
-    @deserializer     = nil
+    @encoder          = nil
+    @decoder          = nil
     @client           = nil
     @redis            = nil
     true
@@ -53,12 +53,12 @@ module Qs
     @client.push(queue_name, payload)
   end
 
-  def self.serialize(payload)
-    @serializer.call(payload)
+  def self.encode(payload)
+    @encoder.call(payload)
   end
 
-  def self.deserialize(serialized_payload)
-    @deserializer.call(serialized_payload)
+  def self.decode(encoded_payload)
+    @decoder.call(encoded_payload)
   end
 
   def self.sync_subscriptions(queue)
@@ -99,8 +99,8 @@ module Qs
     option :dispatcher_name,     String, :default => 'dispatcher'
     option :dispatcher_job_name, String, :default => 'dispatch_event'
 
-    option :serializer,   Proc, :default => proc{ |p| ::JSON.dump(p) }
-    option :deserializer, Proc, :default => proc{ |p| ::JSON.load(p) }
+    option :encoder, Proc, :default => proc{ |p| ::JSON.dump(p) }
+    option :decoder, Proc, :default => proc{ |p| ::JSON.load(p) }
 
     option :timeout, Float
 

--- a/lib/qs/error_handler.rb
+++ b/lib/qs/error_handler.rb
@@ -31,24 +31,24 @@ module Qs
 
   class ErrorContext
     attr_reader :daemon_data
-    attr_reader :queue_name, :serialized_payload
+    attr_reader :queue_name, :encoded_payload
     attr_reader :job, :handler_class
 
     def initialize(args)
-      @daemon_data        = args[:daemon_data]
-      @queue_name         = Queue::RedisKey.parse_name(args[:queue_redis_key].to_s)
-      @serialized_payload = args[:serialized_payload]
-      @job                = args[:job]
-      @handler_class      = args[:handler_class]
+      @daemon_data     = args[:daemon_data]
+      @queue_name      = Queue::RedisKey.parse_name(args[:queue_redis_key].to_s)
+      @encoded_payload = args[:encoded_payload]
+      @job             = args[:job]
+      @handler_class   = args[:handler_class]
     end
 
     def ==(other)
       if other.kind_of?(self.class)
-        self.daemon_data        == other.daemon_data &&
-        self.queue_name         == other.queue_name &&
-        self.serialized_payload == other.serialized_payload &&
-        self.job                == other.job &&
-        self.handler_class      == other.handler_class
+        self.daemon_data     == other.daemon_data &&
+        self.queue_name      == other.queue_name &&
+        self.encoded_payload == other.encoded_payload &&
+        self.job             == other.job &&
+        self.handler_class   == other.handler_class
       else
         super
       end

--- a/lib/qs/job.rb
+++ b/lib/qs/job.rb
@@ -4,14 +4,6 @@ module Qs
 
     PAYLOAD_TYPE = 'job'
 
-    def self.parse(payload)
-      created_at = Time.at(payload['created_at'].to_i)
-      self.new(payload['name'], payload['params'], {
-        :type       => payload['type'],
-        :created_at => created_at
-      })
-    end
-
     attr_reader :payload_type, :name, :params, :created_at
 
     def initialize(name, params, options = nil)
@@ -30,14 +22,6 @@ module Qs
       @route_name ||= RouteName.new(self.payload_type, self.name)
     end
 
-    def to_payload
-      { 'type'       => self.payload_type.to_s,
-        'name'       => self.name.to_s,
-        'params'     => StringifyParams.new(self.params),
-        'created_at' => self.created_at.to_i
-      }
-    end
-
     def inspect
       reference = '0x0%x' % (self.object_id << 1)
       "#<#{self.class}:#{reference} " \
@@ -48,7 +32,10 @@ module Qs
 
     def ==(other)
       if other.kind_of?(self.class)
-        self.to_payload == other.to_payload
+        self.payload_type == other.payload_type &&
+        self.name         == other.name         &&
+        self.params       == other.params       &&
+        self.created_at   == other.created_at
       else
         super
       end
@@ -68,19 +55,6 @@ module Qs
     module RouteName
       def self.new(payload_type, name)
         "#{payload_type}|#{name}"
-      end
-    end
-
-    module StringifyParams
-      def self.new(object)
-        case(object)
-        when Hash
-          object.inject({}){ |h, (k, v)| h.merge(k.to_s => self.new(v)) }
-        when Array
-          object.map{ |item| self.new(item) }
-        else
-          object
-        end
       end
     end
 

--- a/lib/qs/job_test_runner.rb
+++ b/lib/qs/job_test_runner.rb
@@ -1,8 +1,8 @@
 require 'qs'
 require 'qs/event'
 require 'qs/event_handler'
-require 'qs/job'
 require 'qs/job_handler'
+require 'qs/payload'
 require 'qs/runner'
 
 module Qs
@@ -32,11 +32,11 @@ module Qs
 
     private
 
-    # Stringify and serialize/deserialize to ensure params are valid and are
+    # Stringify and encode/decode to ensure params are valid and are
     # in the format they would normally be when a handler is built and run.
     def normalize_params(params)
-      params = Job::StringifyParams.new(params)
-      Qs.deserialize(Qs.serialize(params))
+      params = Qs::Payload::StringifyParams.new(params)
+      Qs.decode(Qs.encode(params))
     end
 
   end

--- a/lib/qs/payload.rb
+++ b/lib/qs/payload.rb
@@ -1,0 +1,46 @@
+require 'qs'
+require 'qs/job'
+
+module Qs
+
+  module Payload
+
+    def self.deserialize(encoded_payload)
+      self.job(Qs.decode(encoded_payload))
+    end
+
+    def self.job(payload_hash)
+      Qs::Job.new(payload_hash['name'], payload_hash['params'], {
+        :type       => payload_hash['type'],
+        :created_at => Time.at(payload_hash['created_at'].to_i)
+      })
+    end
+
+    def self.serialize(job)
+      Qs.encode(self.job_hash(job))
+    end
+
+    def self.job_hash(job)
+      { 'type'       => job.payload_type.to_s,
+        'name'       => job.name.to_s,
+        'params'     => StringifyParams.new(job.params),
+        'created_at' => job.created_at.to_i
+      }
+    end
+
+    module StringifyParams
+      def self.new(object)
+        case(object)
+        when Hash
+          object.inject({}){ |h, (k, v)| h.merge(k.to_s => self.new(v)) }
+        when Array
+          object.map{ |item| self.new(item) }
+        else
+          object
+        end
+      end
+    end
+
+  end
+
+end

--- a/lib/qs/redis_item.rb
+++ b/lib/qs/redis_item.rb
@@ -2,16 +2,16 @@ module Qs
 
   class RedisItem
 
-    attr_reader :queue_redis_key, :serialized_payload
+    attr_reader :queue_redis_key, :encoded_payload
     attr_accessor :started, :finished
     attr_accessor :job, :handler_class
     attr_accessor :exception, :time_taken
 
-    def initialize(queue_redis_key, serialized_payload)
-      @queue_redis_key    = queue_redis_key
-      @serialized_payload = serialized_payload
-      @started            = false
-      @finished           = false
+    def initialize(queue_redis_key, encoded_payload)
+      @queue_redis_key = queue_redis_key
+      @encoded_payload = encoded_payload
+      @started         = false
+      @finished        = false
 
       @job           = nil
       @handler_class = nil
@@ -21,8 +21,8 @@ module Qs
 
     def ==(other)
       if other.kind_of?(self.class)
-        self.queue_redis_key    == other.queue_redis_key &&
-        self.serialized_payload == other.serialized_payload
+        self.queue_redis_key == other.queue_redis_key &&
+        self.encoded_payload == other.encoded_payload
       else
         super
       end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -11,4 +11,4 @@ ROOT_PATH = Pathname.new(File.expand_path('../..', __FILE__))
 
 require 'test/support/factory'
 
-require 'json' # so the default serializer/deserializer procs will work
+require 'json' # so the default encoder/decoder procs will work

--- a/test/system/daemon_tests.rb
+++ b/test/system/daemon_tests.rb
@@ -190,8 +190,8 @@ module Qs::Daemon
       @thread.join 2 # give it time to shutdown, should be faster
       assert_false @thread.alive?
       # TODO - better way to read whats on a queue
-      serialized_payloads = Qs.redis.with{ |c| c.lrange(AppQueue.redis_key, 0, 3) }
-      names = serialized_payloads.map{ |sp| Qs::Job.parse(Qs.deserialize(sp)).name }
+      encoded_payloads = Qs.redis.with{ |c| c.lrange(AppQueue.redis_key, 0, 3) }
+      names = encoded_payloads.map{ |sp| Qs::Payload.deserialize(sp).name }
       assert_equal ['basic', 'slow', 'slow'], names
     end
 
@@ -200,8 +200,8 @@ module Qs::Daemon
       @thread.join 2 # give it time to shutdown, should be faster
       assert_false @thread.alive?
       # TODO - better way to read whats on a queue
-      serialized_payloads = Qs.redis.with{ |c| c.lrange(AppQueue.redis_key, 0, 3) }
-      names = serialized_payloads.map{ |sp| Qs::Job.parse(Qs.deserialize(sp)).name }
+      encoded_payloads = Qs.redis.with{ |c| c.lrange(AppQueue.redis_key, 0, 3) }
+      names = encoded_payloads.map{ |sp| Qs::Payload.deserialize(sp).name }
       assert_equal ['basic', 'slow', 'slow'], names
     end
 

--- a/test/unit/daemon_tests.rb
+++ b/test/unit/daemon_tests.rb
@@ -275,8 +275,8 @@ module Qs::Daemon
       @daemon = @daemon_class.new
       @thread = @daemon.start
 
-      @serialized_payload = Factory.string
-      @client_spy.append(@queue.redis_key, @serialized_payload)
+      @encoded_payload = Factory.string
+      @client_spy.append(@queue.redis_key, @encoded_payload)
     end
     subject{ @daemon }
 
@@ -285,7 +285,7 @@ module Qs::Daemon
       assert_equal :block_dequeue, call.command
       exp = [subject.signals_redis_key, subject.queue_redis_keys, 0].flatten
       assert_equal exp, call.args
-      exp = Qs::RedisItem.new(@queue.redis_key, @serialized_payload)
+      exp = Qs::RedisItem.new(@queue.redis_key, @encoded_payload)
       assert_equal exp, @worker_pool_spy.work_items.first
     end
 
@@ -383,8 +383,8 @@ module Qs::Daemon
       @callback.call('worker', @exception, @redis_item)
       call = @client_spy.calls.detect{ |c| c.command == :prepend }
       assert_not_nil call
-      assert_equal @redis_item.queue_redis_key,    call.args.first
-      assert_equal @redis_item.serialized_payload, call.args.last
+      assert_equal @redis_item.queue_redis_key, call.args.first
+      assert_equal @redis_item.encoded_payload, call.args.last
     end
 
     should "not requeue the redis item if it was started" do
@@ -416,8 +416,8 @@ module Qs::Daemon
     should "requeue any work left on the pool" do
       call = @client_spy.calls.last
       assert_equal :prepend, call.command
-      assert_equal @redis_item.queue_redis_key,    call.args.first
-      assert_equal @redis_item.serialized_payload, call.args.last
+      assert_equal @redis_item.queue_redis_key, call.args.first
+      assert_equal @redis_item.encoded_payload, call.args.last
     end
 
     should "stop the work loop thread" do
@@ -463,8 +463,8 @@ module Qs::Daemon
     should "requeue any work left on the pool" do
       call = @client_spy.calls.last
       assert_equal :prepend, call.command
-      assert_equal @redis_item.queue_redis_key,    call.args.first
-      assert_equal @redis_item.serialized_payload, call.args.last
+      assert_equal @redis_item.queue_redis_key, call.args.first
+      assert_equal @redis_item.encoded_payload, call.args.last
     end
 
     should "stop the work loop thread" do
@@ -502,7 +502,7 @@ module Qs::Daemon
       # cause the daemon to loop, its sleeping on the original block_dequeue
       # call that happened before the stub
       @redis_item = Qs::RedisItem.new(@queue.redis_key, Factory.string)
-      @client_spy.append(@redis_item.queue_redis_key, @redis_item.serialized_payload)
+      @client_spy.append(@redis_item.queue_redis_key, @redis_item.encoded_payload)
     end
 
     should "shutdown the worker pool" do
@@ -513,8 +513,8 @@ module Qs::Daemon
     should "requeue any work left on the pool" do
       call = @client_spy.calls.last
       assert_equal :prepend, call.command
-      assert_equal @redis_item.queue_redis_key,    call.args.first
-      assert_equal @redis_item.serialized_payload, call.args.last
+      assert_equal @redis_item.queue_redis_key, call.args.first
+      assert_equal @redis_item.encoded_payload, call.args.last
     end
 
     should "stop the work loop thread" do

--- a/test/unit/error_handler_tests.rb
+++ b/test/unit/error_handler_tests.rb
@@ -13,11 +13,11 @@ class Qs::ErrorHandler
       @daemon_data     = Qs::DaemonData.new
       @queue_redis_key = Qs::Queue::RedisKey.new(Factory.string)
       @context_hash    = {
-        :daemon_data        => @daemon_data,
-        :queue_redis_key    => @queue_redis_key,
-        :serialized_payload => Factory.string,
-        :job                => Factory.string,
-        :handler_class      => Factory.string
+        :daemon_data     => @daemon_data,
+        :queue_redis_key => @queue_redis_key,
+        :encoded_payload => Factory.string,
+        :job             => Factory.string,
+        :handler_class   => Factory.string
       }
 
       @handler_class = Qs::ErrorHandler
@@ -107,14 +107,14 @@ class Qs::ErrorHandler
     subject{ @context }
 
     should have_readers :daemon_data
-    should have_readers :queue_name, :serialized_payload
+    should have_readers :queue_name, :encoded_payload
     should have_readers :job, :handler_class
 
     should "know its attributes" do
       assert_equal @context_hash[:daemon_data], subject.daemon_data
       exp = Qs::Queue::RedisKey.parse_name(@context_hash[:queue_redis_key])
       assert_equal exp, subject.queue_name
-      assert_equal @context_hash[:serialized_payload], subject.serialized_payload
+      assert_equal @context_hash[:encoded_payload], subject.encoded_payload
       assert_equal @context_hash[:job], subject.job
       assert_equal @context_hash[:handler_class], subject.handler_class
     end

--- a/test/unit/job_test_runner_tests.rb
+++ b/test/unit/job_test_runner_tests.rb
@@ -71,7 +71,7 @@ class Qs::JobTestRunner
       assert_nil @handler.after_called
     end
 
-    should "stringify and serialize the params passed to it" do
+    should "stringify and encode the params passed to it" do
       key, value = Factory.string.to_sym, Factory.string
       params = {
         key    => value,
@@ -140,7 +140,7 @@ class Qs::JobTestRunner
         @args[:event_channel],
         @args[:event_name],
         @args[:params],
-        @args[:event_published_at]
+        { :published_at => @args[:event_published_at] }
       ).job
       assert_equal exp_job,        subject.job
       assert_equal exp_job.params, subject.params

--- a/test/unit/job_tests.rb
+++ b/test/unit/job_tests.rb
@@ -15,25 +15,8 @@ class Qs::Job
     end
     subject{ @job_class }
 
-    should have_imeths :parse
-
     should "know its payload type" do
       assert_equal 'job', PAYLOAD_TYPE
-    end
-
-    should "parse a job from a payload hash" do
-      payload = {
-        'type'       => @payload_type,
-        'name'       => @name,
-        'params'     => @params,
-        'created_at' => @created_at.to_i
-      }
-      job = subject.parse(payload)
-      assert_instance_of subject, job
-      assert_equal payload['type'], job.payload_type
-      assert_equal payload['name'], job.name
-      assert_equal payload['params'], job.params
-      assert_equal Time.at(payload['created_at']), job.created_at
     end
 
   end
@@ -52,7 +35,7 @@ class Qs::Job
     subject{ @job }
 
     should have_readers :payload_type, :name, :params, :created_at
-    should have_imeths :route_name, :to_payload
+    should have_imeths :route_name
 
     should "know its payload type, name, params and created at" do
       assert_equal @payload_type, subject.payload_type
@@ -65,30 +48,6 @@ class Qs::Job
       job = @job_class.new(@name, @params)
       assert_equal PAYLOAD_TYPE,  job.payload_type
       assert_equal @current_time, job.created_at
-    end
-
-    should "return a payload hash using `to_payload`" do
-      exp = {
-        'type'       => @payload_type,
-        'name'       => @name,
-        'params'     => @params,
-        'created_at' => @created_at.to_i
-      }
-      assert_equal exp, subject.to_payload
-    end
-
-    should "sanitize its attributes with `to_payload`" do
-      params = { Factory.string.to_sym => Factory.string }
-      payload = @job_class.new(@name.to_sym, params, {
-        :type       => @payload_type.to_sym,
-        :created_at => @created_at
-      }).to_payload
-
-      assert_equal @payload_type, payload['type']
-      assert_equal @name, payload['name']
-      exp = StringifyParams.new(params)
-      assert_equal exp, payload['params']
-      assert_equal @created_at.to_i, payload['created_at']
     end
 
     should "raise an error when given an invalid name or params" do
@@ -107,11 +66,33 @@ class Qs::Job
     end
 
     should "be comparable" do
-      other_job = @job_class.new(@name, @params)
-      Assert.stub(other_job, :to_payload){ subject.to_payload }
-      assert_equal other_job, subject
-      Assert.stub(other_job, :to_payload){ Hash.new }
-      assert_not_equal other_job, subject
+      matching_job = @job_class.new(@name, @params, {
+        :type       => @payload_type,
+        :created_at => @created_at
+      })
+      assert_equal matching_job, subject
+
+      non_matching_job = @job_class.new(Factory.string, @params, {
+        :type       => @payload_type,
+        :created_at => @created_at
+      })
+      assert_not_equal non_matching_job, subject
+      other_params = { Factory.string => Factory.string }
+      non_matching_job = @job_class.new(@name, other_params, {
+        :type       => @payload_type,
+        :created_at => @created_at
+      })
+      assert_not_equal non_matching_job, subject
+      non_matching_job = @job_class.new(@name, @params, {
+        :type       => Factory.string,
+        :created_at => @created_at
+      })
+      assert_not_equal non_matching_job, subject
+      non_matching_job = @job_class.new(@name, @params, {
+        :type       => @payload_type,
+        :created_at => Factory.time
+      })
+      assert_not_equal non_matching_job, subject
     end
 
   end
@@ -129,27 +110,6 @@ class Qs::Job
 
   end
 
-  class StringifyParamsTests < UnitTests
-    desc "StringifyParams"
-    subject{ StringifyParams }
 
-    should have_imeths :new
-
-    should "convert all hash keys to strings" do
-      key, value = Factory.string.to_sym, Factory.string
-      result = subject.new({
-        key    => value,
-        :hash  => { key => [value] },
-        :array => [{ key => value }]
-      })
-      exp = {
-        key.to_s => value,
-        'hash'   => { key.to_s => [value] },
-        'array'  => [{ key.to_s => value }]
-      }
-      assert_equal exp, result
-    end
-
-  end
 
 end

--- a/test/unit/payload_handler_tests.rb
+++ b/test/unit/payload_handler_tests.rb
@@ -26,8 +26,8 @@ class Qs::PayloadHandler
         :logger => Qs::NullLogger.new,
         :routes => [@route_spy]
       })
-      serialized_payload = Qs.serialize(@job.to_payload)
-      @redis_item = Qs::RedisItem.new(Factory.string, serialized_payload)
+      encoded_payload = Qs::Payload.serialize(@job)
+      @redis_item = Qs::RedisItem.new(Factory.string, encoded_payload)
 
       Assert.stub(Qs::Logger, :new){ |*args| QsLoggerSpy.new(*args) }
 
@@ -114,11 +114,11 @@ class Qs::PayloadHandler
     should "run an error handler" do
       assert_equal @route_exception, @error_handler_spy.passed_exception
       exp = {
-        :daemon_data        => @daemon_data,
-        :queue_redis_key    => @redis_item.queue_redis_key,
-        :serialized_payload => @redis_item.serialized_payload,
-        :job                => @redis_item.job,
-        :handler_class      => @redis_item.handler_class
+        :daemon_data     => @daemon_data,
+        :queue_redis_key => @redis_item.queue_redis_key,
+        :encoded_payload => @redis_item.encoded_payload,
+        :job             => @redis_item.job,
+        :handler_class   => @redis_item.handler_class
       }
       assert_equal exp, @error_handler_spy.context_hash
       assert_true @error_handler_spy.run_called

--- a/test/unit/payload_tests.rb
+++ b/test/unit/payload_tests.rb
@@ -1,0 +1,79 @@
+require 'assert'
+require 'qs/payload'
+
+module Qs::Payload
+
+  class UnitTests < Assert::Context
+    desc "Qs::Payload"
+    setup do
+      # the default JSON encoder/decoder is not deterministic, the keys in the
+      # string can be randomly ordered
+      Assert.stub(Qs, :encode){ |hash| hash.to_a.sort }
+      Assert.stub(Qs, :decode){ |array| Hash[array] }
+
+      @job = Factory.job
+    end
+    subject{ Qs::Payload }
+
+    should have_imeths :deserialize, :job
+    should have_imeths :serialize, :job_hash
+
+    should "serialize and deserialize jobs" do
+      encoded_payload = subject.serialize(@job)
+      exp = Qs.encode(subject.job_hash(@job))
+      assert_equal exp, encoded_payload
+      deserialized_job = subject.deserialize(encoded_payload)
+      assert_equal @job, deserialized_job
+    end
+
+    should "build jobs and payload hashes" do
+      payload_hash = {
+        'type'       => @job.payload_type,
+        'name'       => @job.name,
+        'params'     => @job.params,
+        'created_at' => @job.created_at.to_i
+      }
+      assert_equal @job, subject.job(payload_hash)
+      assert_equal payload_hash, subject.job_hash(@job)
+    end
+
+    should "sanitize its jobs attributes when building a payload hash" do
+      job = Factory.job({
+        :type   => Factory.string.to_sym,
+        :name   => Factory.string.to_sym,
+        :params => { Factory.string.to_sym => Factory.string }
+      })
+      payload_hash = subject.job_hash(job)
+
+      assert_equal job.payload_type.to_s, payload_hash['type']
+      assert_equal job.name.to_s, payload_hash['name']
+      exp = StringifyParams.new(job.params)
+      assert_equal exp, payload_hash['params']
+    end
+
+  end
+
+  class StringifyParamsTests < UnitTests
+    desc "StringifyParams"
+    subject{ StringifyParams }
+
+    should have_imeths :new
+
+    should "convert all hash keys to strings" do
+      key, value = Factory.string.to_sym, Factory.string
+      result = subject.new({
+        key    => value,
+        :hash  => { key => [value] },
+        :array => [{ key => value }]
+      })
+      exp = {
+        key.to_s => value,
+        'hash'   => { key.to_s => [value] },
+        'array'  => [{ key.to_s => value }]
+      }
+      assert_equal exp, result
+    end
+
+  end
+
+end

--- a/test/unit/redis_item_tests.rb
+++ b/test/unit/redis_item_tests.rb
@@ -1,25 +1,27 @@
 require 'assert'
 require 'qs/redis_item'
 
+require 'qs/queue'
+
 class Qs::RedisItem
 
   class UnitTests < Assert::Context
     desc "Qs::RedisItem"
     setup do
-      @queue_redis_key    = Factory.string
-      @serialized_payload = Factory.string
-      @redis_item = Qs::RedisItem.new(@queue_redis_key, @serialized_payload)
+      @queue_redis_key = Factory.string
+      @encoded_payload = Factory.string
+      @redis_item = Qs::RedisItem.new(@queue_redis_key, @encoded_payload)
     end
     subject{ @redis_item }
 
-    should have_readers :queue_redis_key, :serialized_payload
+    should have_readers :queue_redis_key, :encoded_payload
     should have_accessors :started, :finished
     should have_accessors :job, :handler_class
     should have_accessors :exception, :time_taken
 
-    should "know its queue redis key and serialized payload" do
-      assert_equal @queue_redis_key,    subject.queue_redis_key
-      assert_equal @serialized_payload, subject.serialized_payload
+    should "know its queue redis key and encoded payload" do
+      assert_equal @queue_redis_key, subject.queue_redis_key
+      assert_equal @encoded_payload, subject.encoded_payload
     end
 
     should "defaults its other attributes" do
@@ -33,11 +35,11 @@ class Qs::RedisItem
     end
 
     should "know if it equals another item" do
-      exp = Qs::RedisItem.new(@queue_redis_key, @serialized_payload)
+      exp = Qs::RedisItem.new(@queue_redis_key, @encoded_payload)
       assert_equal exp, subject
 
       redis_key = Qs::Queue::RedisKey.new(Factory.string)
-      exp = Qs::RedisItem.new(redis_key, @serialized_payload)
+      exp = Qs::RedisItem.new(redis_key, @encoded_payload)
       assert_not_equal exp, subject
 
       exp = Qs::RedisItem.new(@queue_redis_key, Factory.string)


### PR DESCRIPTION
This adds a `Payload` module that is responsible for serializing
jobs and deserializing serialized payloads. This doesn't change
any functionality; its just an organization change. It centralizes
all the serialization and deserialization for jobs into one
location and is setup for changing events to inherit from job.

@kellyredding - Ready for review.