### PR TITLE
Add `Message`, setup `Event` being a kind of `Message`

### DIFF
--- a/lib/qs/daemon_data.rb
+++ b/lib/qs/daemon_data.rb
@@ -29,14 +29,14 @@ module Qs
       @routes           = build_routes(args[:routes] || [])
     end
 
-    def route_for(route_name)
-      @routes[route_name] || raise(NotFoundError, "no job named '#{route_name}'")
+    def route_for(route_id)
+      @routes[route_id] || raise(NotFoundError, "unknown message '#{route_id}'")
     end
 
     private
 
     def build_routes(routes)
-      routes.inject({}){ |h, route| h.merge(route.name => route) }
+      routes.inject({}){ |h, route| h.merge(route.id => route) }
     end
 
   end

--- a/lib/qs/error_handler.rb
+++ b/lib/qs/error_handler.rb
@@ -32,13 +32,13 @@ module Qs
   class ErrorContext
     attr_reader :daemon_data
     attr_reader :queue_name, :encoded_payload
-    attr_reader :job, :handler_class
+    attr_reader :message, :handler_class
 
     def initialize(args)
       @daemon_data     = args[:daemon_data]
       @queue_name      = Queue::RedisKey.parse_name(args[:queue_redis_key].to_s)
       @encoded_payload = args[:encoded_payload]
-      @job             = args[:job]
+      @message         = args[:message]
       @handler_class   = args[:handler_class]
     end
 
@@ -47,7 +47,7 @@ module Qs
         self.daemon_data     == other.daemon_data &&
         self.queue_name      == other.queue_name &&
         self.encoded_payload == other.encoded_payload &&
-        self.job             == other.job &&
+        self.message         == other.message &&
         self.handler_class   == other.handler_class
       else
         super

--- a/lib/qs/job.rb
+++ b/lib/qs/job.rb
@@ -1,25 +1,26 @@
+require 'qs/message'
+
 module Qs
 
-  class Job
+  class Job < Message
 
     PAYLOAD_TYPE = 'job'
 
-    attr_reader :payload_type, :name, :params, :created_at
+    attr_reader :name, :created_at
 
     def initialize(name, params, options = nil)
       options ||= {}
-      options[:type]       = PAYLOAD_TYPE unless options.key?(:type)
-      options[:created_at] = Time.now     unless options.key?(:created_at)
-
+      # TODO - remove once Event doesn't build Job
+      options[:type] = PAYLOAD_TYPE unless options.key?(:type)
       validate!(name, params)
-      @payload_type = options[:type]
-      @name         = name
-      @params       = params
-      @created_at   = options[:created_at]
+      @name       = name
+      @created_at = options[:created_at] || Time.now
+      # TODO - change options[:type] to PAYLOAD_TYPE once Event doesn't build Job
+      super(options[:type], params)
     end
 
     def route_name
-      @route_name ||= RouteName.new(self.payload_type, self.name)
+      self.name
     end
 
     def inspect
@@ -50,12 +51,6 @@ module Qs
         "The job's params are not valid."
       end
       raise(BadJobError, problem) if problem
-    end
-
-    module RouteName
-      def self.new(payload_type, name)
-        "#{payload_type}|#{name}"
-      end
     end
 
   end

--- a/lib/qs/message.rb
+++ b/lib/qs/message.rb
@@ -1,0 +1,28 @@
+module Qs
+
+  class Message
+
+    attr_reader :payload_type, :params
+
+    def initialize(payload_type, params = nil)
+      @payload_type = payload_type.to_s
+      @params       = params || {}
+    end
+
+    def route_id
+      @route_id ||= RouteId.new(self.payload_type, self.route_name)
+    end
+
+    def route_name
+      raise NotImplementedError
+    end
+
+    module RouteId
+      def self.new(payload_type, route_name)
+        "#{payload_type}|#{route_name}"
+      end
+    end
+
+  end
+
+end

--- a/lib/qs/payload.rb
+++ b/lib/qs/payload.rb
@@ -16,8 +16,8 @@ module Qs
       })
     end
 
-    def self.serialize(job)
-      Qs.encode(self.job_hash(job))
+    def self.serialize(message)
+      Qs.encode(self.job_hash(message))
     end
 
     def self.job_hash(job)

--- a/lib/qs/queue.rb
+++ b/lib/qs/queue.rb
@@ -40,8 +40,8 @@ module Qs
         handler_name = "#{self.job_handler_ns}::#{handler_name}"
       end
 
-      route_name = Qs::Job::RouteName.new(Qs::Job::PAYLOAD_TYPE, name)
-      @routes.push(Qs::Route.new(route_name, handler_name))
+      route_id = Message::RouteId.new(Qs::Job::PAYLOAD_TYPE, name)
+      @routes.push(Qs::Route.new(route_id, handler_name))
     end
 
     def event(channel, name, handler_name)
@@ -50,10 +50,10 @@ module Qs
       end
 
       job_name = Qs::Event::JobName.new(channel, name)
-      route_name = Qs::Job::RouteName.new(Qs::Event::PAYLOAD_TYPE, job_name)
+      route_id = Qs::Message::RouteId.new(Qs::Event::PAYLOAD_TYPE, job_name)
 
       @event_job_names.push(job_name)
-      @routes.push(Qs::Route.new(route_name, handler_name))
+      @routes.push(Qs::Route.new(route_id, handler_name))
     end
 
     def enqueue(job_name, params = nil)

--- a/lib/qs/redis_item.rb
+++ b/lib/qs/redis_item.rb
@@ -4,7 +4,7 @@ module Qs
 
     attr_reader :queue_redis_key, :encoded_payload
     attr_accessor :started, :finished
-    attr_accessor :job, :handler_class
+    attr_accessor :message, :handler_class
     attr_accessor :exception, :time_taken
 
     def initialize(queue_redis_key, encoded_payload)
@@ -13,7 +13,7 @@ module Qs
       @started         = false
       @finished        = false
 
-      @job           = nil
+      @message       = nil
       @handler_class = nil
       @exception     = nil
       @time_taken    = nil

--- a/lib/qs/route.rb
+++ b/lib/qs/route.rb
@@ -4,10 +4,10 @@ module Qs
 
   class Route
 
-    attr_reader :name, :handler_class_name, :handler_class
+    attr_reader :id, :handler_class_name, :handler_class
 
-    def initialize(job_route_name, handler_class_name)
-      @name = job_route_name.to_s
+    def initialize(route_id, handler_class_name)
+      @id = route_id.to_s
       @handler_class_name = handler_class_name
       @handler_class = nil
     end

--- a/test/support/app_daemon.rb
+++ b/test/support/app_daemon.rb
@@ -25,8 +25,8 @@ class AppDaemon
   queue AppQueue
 
   error do |exception, context|
-    job_name = context.job.name if context.job
-    case(job_name)
+    route_name = context.message.route_name if context.message
+    case(route_name)
     when 'error', 'timeout'
       message = "#{exception.class}: #{exception.message}"
       Qs.redis.with{ |c| c.set('last_error', message) }

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -13,6 +13,10 @@ module Factory
     exception
   end
 
+  def self.message(params = nil)
+    self.send([:job, :event_job].choice, params)
+  end
+
   def self.job(params = nil)
     params ||= {}
     params[:name]       ||= Factory.string

--- a/test/unit/daemon_data_tests.rb
+++ b/test/unit/daemon_data_tests.rb
@@ -59,14 +59,14 @@ class Qs::DaemonData
     end
 
     should "build a routes lookup hash" do
-      expected = @routes.inject({}){ |h, r| h.merge(r.name => r) }
+      expected = @routes.inject({}){ |h, r| h.merge(r.id => r) }
       assert_equal expected, subject.routes
     end
 
     should "allow looking up a route using `route_for`" do
-      expected = @routes.choice
-      route = subject.route_for(expected.name)
-      assert_equal expected, route
+      exp_route = @routes.choice
+      route = subject.route_for(exp_route.id)
+      assert_equal exp_route, route
     end
 
     should "raise a not found error using `route_for` with an invalid name" do

--- a/test/unit/error_handler_tests.rb
+++ b/test/unit/error_handler_tests.rb
@@ -16,7 +16,7 @@ class Qs::ErrorHandler
         :daemon_data     => @daemon_data,
         :queue_redis_key => @queue_redis_key,
         :encoded_payload => Factory.string,
-        :job             => Factory.string,
+        :message         => Factory.string,
         :handler_class   => Factory.string
       }
 
@@ -108,14 +108,14 @@ class Qs::ErrorHandler
 
     should have_readers :daemon_data
     should have_readers :queue_name, :encoded_payload
-    should have_readers :job, :handler_class
+    should have_readers :message, :handler_class
 
     should "know its attributes" do
       assert_equal @context_hash[:daemon_data], subject.daemon_data
       exp = Qs::Queue::RedisKey.parse_name(@context_hash[:queue_redis_key])
       assert_equal exp, subject.queue_name
       assert_equal @context_hash[:encoded_payload], subject.encoded_payload
-      assert_equal @context_hash[:job], subject.job
+      assert_equal @context_hash[:message], subject.message
       assert_equal @context_hash[:handler_class], subject.handler_class
     end
 

--- a/test/unit/job_tests.rb
+++ b/test/unit/job_tests.rb
@@ -35,7 +35,6 @@ class Qs::Job
     subject{ @job }
 
     should have_readers :payload_type, :name, :params, :created_at
-    should have_imeths :route_name
 
     should "know its payload type, name, params and created at" do
       assert_equal @payload_type, subject.payload_type
@@ -96,20 +95,5 @@ class Qs::Job
     end
 
   end
-
-  class RouteNameTests < UnitTests
-    desc "RouteName"
-    subject{ RouteName }
-
-    should have_imeths :new
-
-    should "build a route name given a payload type and name" do
-      exp = "#{@payload_type}|#{@name}"
-      assert_equal exp, RouteName.new(@payload_type, @name)
-    end
-
-  end
-
-
 
 end

--- a/test/unit/message_tests.rb
+++ b/test/unit/message_tests.rb
@@ -1,0 +1,64 @@
+require 'assert'
+require 'qs/message'
+
+class Qs::Message
+
+  class UnitTests < Assert::Context
+    desc "Qs::Message"
+    setup do
+      @payload_type  = Factory.string
+      @params        = { Factory.string => Factory.string }
+      @message_class = Qs::Message
+    end
+    subject{ @message_class }
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @message = @message_class.new(@payload_type, @params)
+    end
+    subject{ @message }
+
+    should have_readers :payload_type, :params
+    should have_imeths :route_id, :route_name
+
+    should "know its payload type and params" do
+      assert_equal @payload_type, subject.payload_type
+      assert_equal @params, subject.params
+    end
+
+    should "default its params" do
+      message = @message_class.new(@payload_type)
+      assert_equal({}, message.params)
+    end
+
+    should "know its route id" do
+      route_name = Factory.string
+      Assert.stub(subject, :route_name){ route_name }
+
+      exp = RouteId.new(@payload_type, route_name)
+      assert_equal exp, subject.route_id
+    end
+
+    should "raise a not implement error for its route name" do
+      assert_raises(NotImplementedError){ subject.route_name }
+    end
+
+  end
+
+  class RouteIdTests < UnitTests
+    desc "RouteId"
+    subject{ RouteId }
+
+    should have_imeths :new
+
+    should "build a route id given a payload type and a route name" do
+      exp = "#{@payload_type}|#{@name}"
+      assert_equal exp, subject.new(@payload_type, @name)
+    end
+
+  end
+
+end

--- a/test/unit/queue_tests.rb
+++ b/test/unit/queue_tests.rb
@@ -65,8 +65,8 @@ class Qs::Queue
 
       route = subject.routes.last
       assert_instance_of Qs::Route, route
-      exp = Qs::Job::RouteName.new(Qs::Job::PAYLOAD_TYPE, job_name)
-      assert_equal exp, route.name
+      exp = Qs::Message::RouteId.new(Qs::Job::PAYLOAD_TYPE, job_name)
+      assert_equal exp, route.id
       assert_equal handler_name, route.handler_class_name
     end
 
@@ -104,8 +104,8 @@ class Qs::Queue
       route = subject.routes.last
       assert_instance_of Qs::Route, route
       job_name = Qs::Event::JobName.new(event_channel, event_name)
-      exp = Qs::Job::RouteName.new(Qs::Event::PAYLOAD_TYPE, job_name)
-      assert_equal exp, route.name
+      exp = Qs::Message::RouteId.new(Qs::Event::PAYLOAD_TYPE, job_name)
+      assert_equal exp, route.id
       assert_equal handler_name, route.handler_class_name
     end
 

--- a/test/unit/redis_item_tests.rb
+++ b/test/unit/redis_item_tests.rb
@@ -16,7 +16,7 @@ class Qs::RedisItem
 
     should have_readers :queue_redis_key, :encoded_payload
     should have_accessors :started, :finished
-    should have_accessors :job, :handler_class
+    should have_accessors :message, :handler_class
     should have_accessors :exception, :time_taken
 
     should "know its queue redis key and encoded payload" do
@@ -28,7 +28,7 @@ class Qs::RedisItem
       assert_false subject.started
       assert_false subject.finished
 
-      assert_nil subject.job
+      assert_nil subject.message
       assert_nil subject.handler_class
       assert_nil subject.exception
       assert_nil subject.time_taken

--- a/test/unit/route_tests.rb
+++ b/test/unit/route_tests.rb
@@ -11,17 +11,17 @@ class Qs::Route
   class UnitTests < Assert::Context
     desc "Qs::Route"
     setup do
-      @name = Factory.string
+      @id = Factory.string
       @handler_class_name = TestHandler.to_s
-      @route = Qs::Route.new(@name, @handler_class_name)
+      @route = Qs::Route.new(@id, @handler_class_name)
     end
     subject{ @route }
 
-    should have_readers :name, :handler_class_name, :handler_class
+    should have_readers :id, :handler_class_name, :handler_class
     should have_imeths :validate!, :run
 
-    should "know its name and handler class name" do
-      assert_equal @name, subject.name
+    should "know its id and handler class name" do
+      assert_equal @id, subject.id
       assert_equal @handler_class_name, subject.handler_class_name
     end
 


### PR DESCRIPTION
This adds a base `Message` class, commonizes logic from the `Job`
class and updates `Job` to inherit from it. This is setup for
`Event` no longer composing a job and instead inheriting from
message.

This is part of a larger effort to remove some of the strange
behavior with events composing jobs. The goal is that both jobs
and events are handled the same when routing them to a handler
but they can be distinct in how they handle their name, params and
other data. We currently have consistent handling with routing but
have awkward logic related to making events and jobs distinct. By
making event a message it can be a distinct class but be routed
consistently as a generic message.

Every kind of message has a payload type, route id and params.
These are the common pieces of data that all messages need to
provide so they can added to queues and routed to handlers. Each
message must provide a route name for its route id.

This also renames many uses of `job` to `message` where the object
may be either an event or job and route name to route id. This is
to be explicit about what the object represents and how it can be
used.

@kellyredding - Ready for review.