### PR TITLE
Add `MessageHandler`

### DIFF
--- a/lib/qs/event_handler.rb
+++ b/lib/qs/event_handler.rb
@@ -1,5 +1,5 @@
 require 'qs/event'
-require 'qs/job_handler'
+require 'qs/message_handler'
 
 module Qs
 
@@ -7,6 +7,8 @@ module Qs
 
     def self.included(klass)
       klass.class_eval do
+        include Qs::MessageHandler
+        # TODO - remove once runners are updated to handle messages
         include Qs::JobHandler
         include InstanceMethods
       end
@@ -28,7 +30,12 @@ module Qs
 
       # Helpers
 
-      def event;  @qs_event;        end
+      def event;              @qs_event;          end
+      def event_channel;      event.channel;      end
+      def event_name;         event.name;         end
+      def event_published_at; event.published_at; end
+
+      # TODO - remove once runners are updated to handle messages
       def params; @qs_event.params; end
 
     end

--- a/lib/qs/job_handler.rb
+++ b/lib/qs/job_handler.rb
@@ -1,38 +1,17 @@
+require 'qs/message_handler'
+
 module Qs
 
   module JobHandler
 
     def self.included(klass)
       klass.class_eval do
-        extend ClassMethods
+        include Qs::MessageHandler
         include InstanceMethods
       end
     end
 
     module InstanceMethods
-
-      def initialize(runner)
-        @qs_runner = runner
-      end
-
-      def init
-        run_callback 'before_init'
-        self.init!
-        run_callback 'after_init'
-      end
-
-      def init!
-      end
-
-      def run
-        run_callback 'before_run'
-        self.run!
-        run_callback 'after_run'
-      end
-
-      def run!
-        raise NotImplementedError
-      end
 
       def inspect
         reference = '0x0%x' % (self.object_id << 1)
@@ -43,45 +22,9 @@ module Qs
 
       # Helpers
 
-      def job;    @qs_runner.job;    end
-      def params; @qs_runner.params; end
-      def logger; @qs_runner.logger; end
-
-      def run_callback(callback)
-        (self.class.send("#{callback}_callbacks") || []).each do |callback|
-          self.instance_eval(&callback)
-        end
-      end
-
-    end
-
-    module ClassMethods
-
-      def timeout(value = nil)
-        @timeout = value.to_f if value
-        @timeout
-      end
-
-      def before_callbacks;      @before_callbacks      ||= []; end
-      def after_callbacks;       @after_callbacks       ||= []; end
-      def before_init_callbacks; @before_init_callbacks ||= []; end
-      def after_init_callbacks;  @after_init_callbacks  ||= []; end
-      def before_run_callbacks;  @before_run_callbacks  ||= []; end
-      def after_run_callbacks;   @after_run_callbacks   ||= []; end
-
-      def before(&block);      self.before_callbacks      << block; end
-      def after(&block);       self.after_callbacks       << block; end
-      def before_init(&block); self.before_init_callbacks << block; end
-      def after_init(&block);  self.after_init_callbacks  << block; end
-      def before_run(&block);  self.before_run_callbacks  << block; end
-      def after_run(&block);   self.after_run_callbacks   << block; end
-
-      def prepend_before(&block);      self.before_callbacks.unshift(block);      end
-      def prepend_after(&block);       self.after_callbacks.unshift(block);       end
-      def prepend_before_init(&block); self.before_init_callbacks.unshift(block); end
-      def prepend_after_init(&block);  self.after_init_callbacks.unshift(block);  end
-      def prepend_before_run(&block);  self.before_run_callbacks.unshift(block);  end
-      def prepend_after_run(&block);   self.after_run_callbacks.unshift(block);   end
+      def job;            @qs_runner.job; end
+      def job_name;       job.name;       end
+      def job_created_at; job.created_at; end
 
     end
 

--- a/lib/qs/message_handler.rb
+++ b/lib/qs/message_handler.rb
@@ -1,0 +1,84 @@
+module Qs
+
+  module MessageHandler
+
+    def self.included(klass)
+      klass.class_eval do
+        extend ClassMethods
+        include InstanceMethods
+      end
+    end
+
+    module InstanceMethods
+
+      def initialize(runner)
+        @qs_runner = runner
+      end
+
+      def init
+        run_callback 'before_init'
+        self.init!
+        run_callback 'after_init'
+      end
+
+      def init!
+      end
+
+      def run
+        run_callback 'before_run'
+        self.run!
+        run_callback 'after_run'
+      end
+
+      def run!
+        raise NotImplementedError
+      end
+
+      private
+
+      # Helpers
+
+      def params; @qs_runner.params; end
+      def logger; @qs_runner.logger; end
+
+      def run_callback(callback)
+        (self.class.send("#{callback}_callbacks") || []).each do |callback|
+          self.instance_eval(&callback)
+        end
+      end
+
+    end
+
+    module ClassMethods
+
+      def timeout(value = nil)
+        @timeout = value.to_f if value
+        @timeout
+      end
+
+      def before_callbacks;      @before_callbacks      ||= []; end
+      def after_callbacks;       @after_callbacks       ||= []; end
+      def before_init_callbacks; @before_init_callbacks ||= []; end
+      def after_init_callbacks;  @after_init_callbacks  ||= []; end
+      def before_run_callbacks;  @before_run_callbacks  ||= []; end
+      def after_run_callbacks;   @after_run_callbacks   ||= []; end
+
+      def before(&block);      self.before_callbacks      << block; end
+      def after(&block);       self.after_callbacks       << block; end
+      def before_init(&block); self.before_init_callbacks << block; end
+      def after_init(&block);  self.after_init_callbacks  << block; end
+      def before_run(&block);  self.before_run_callbacks  << block; end
+      def after_run(&block);   self.after_run_callbacks   << block; end
+
+      def prepend_before(&block);      self.before_callbacks.unshift(block);      end
+      def prepend_after(&block);       self.after_callbacks.unshift(block);       end
+      def prepend_before_init(&block); self.before_init_callbacks.unshift(block); end
+      def prepend_after_init(&block);  self.after_init_callbacks.unshift(block);  end
+      def prepend_before_run(&block);  self.before_run_callbacks.unshift(block);  end
+      def prepend_after_run(&block);   self.after_run_callbacks.unshift(block);   end
+
+    end
+
+  end
+
+end

--- a/test/unit/event_handler_tests.rb
+++ b/test/unit/event_handler_tests.rb
@@ -3,6 +3,7 @@ require 'qs/event_handler'
 
 require 'qs/event'
 require 'qs/job_handler'
+require 'qs/message_handler'
 
 module Qs::EventHandler
 
@@ -12,6 +13,10 @@ module Qs::EventHandler
       @handler_class = Class.new{ include Qs::EventHandler }
     end
     subject{ @handler_class }
+
+    should "be a message handler" do
+      assert_includes Qs::MessageHandler, subject
+    end
 
     should "be a job handler" do
       assert_includes Qs::JobHandler, subject
@@ -27,9 +32,17 @@ module Qs::EventHandler
     end
     subject{ @handler }
 
-    should "know its event and params" do
+    should "know its event, channel, name and published at" do
       event = Qs::Event.new(@runner.job)
-      assert_equal event,        subject.public_event
+      assert_equal event,              subject.public_event
+      assert_equal event.channel,      subject.public_event_channel
+      assert_equal event.name,         subject.public_event_name
+      assert_equal event.published_at, subject.public_event_published_at
+    end
+
+    # TODO - remove once runners are updated to handle messages
+    should "know its params" do
+      event = Qs::Event.new(@runner.job)
       assert_equal event.params, subject.public_params
     end
 
@@ -45,8 +58,13 @@ module Qs::EventHandler
   class TestEventHandler
     include Qs::EventHandler
 
+    def public_event;              event;              end
+    def public_event_channel;      event_channel;      end
+    def public_event_name;         event_name;         end
+    def public_event_published_at; event_published_at; end
+
+    # TODO - remove once runners are updated to handle messages
     def public_params; params; end
-    def public_event;  event;  end
   end
 
   class FakeRunner

--- a/test/unit/job_handler_tests.rb
+++ b/test/unit/job_handler_tests.rb
@@ -1,6 +1,8 @@
 require 'assert'
 require 'qs/job_handler'
 
+require 'qs/message_handler'
+
 module Qs::JobHandler
 
   class UnitTests < Assert::Context
@@ -10,136 +12,8 @@ module Qs::JobHandler
     end
     subject{ @handler_class }
 
-    should have_imeths :timeout
-    should have_imeths :before_callbacks, :after_callbacks
-    should have_imeths :before_init_callbacks, :after_init_callbacks
-    should have_imeths :before_run_callbacks,  :after_run_callbacks
-    should have_imeths :before, :after
-    should have_imeths :before_init, :after_init
-    should have_imeths :before_run,  :after_run
-    should have_imeths :prepend_before, :prepend_after
-    should have_imeths :prepend_before_init, :prepend_after_init
-    should have_imeths :prepend_before_run,  :prepend_after_run
-
-    should "allow reading/writing its timeout" do
-      assert_nil subject.timeout
-      value = Factory.integer
-      subject.timeout(value)
-      assert_equal value, subject.timeout
-    end
-
-    should "convert timeout values to floats" do
-      value = Factory.float.to_s
-      subject.timeout(value)
-      assert_equal value.to_f, subject.timeout
-    end
-
-    should "return an empty array by default using `before_callbacks`" do
-      assert_equal [], subject.before_callbacks
-    end
-
-    should "return an empty array by default using `after_callbacks`" do
-      assert_equal [], subject.after_callbacks
-    end
-
-    should "return an empty array by default using `before_init_callbacks`" do
-      assert_equal [], subject.before_init_callbacks
-    end
-
-    should "return an empty array by default using `after_init_callbacks`" do
-      assert_equal [], subject.after_init_callbacks
-    end
-
-    should "return an empty array by default using `before_run_callbacks`" do
-      assert_equal [], subject.before_run_callbacks
-    end
-
-    should "return an empty array by default using `after_run_callbacks`" do
-      assert_equal [], subject.after_run_callbacks
-    end
-
-    should "append a block to the before callbacks using `before`" do
-      subject.before_callbacks << proc{ Factory.string }
-      block = Proc.new{ Factory.string }
-      subject.before(&block)
-      assert_equal block, subject.before_callbacks.last
-    end
-
-    should "append a block to the after callbacks using `after`" do
-      subject.after_callbacks << proc{ Factory.string }
-      block = Proc.new{ Factory.string }
-      subject.after(&block)
-      assert_equal block, subject.after_callbacks.last
-    end
-
-    should "append a block to the before init callbacks using `before_init`" do
-      subject.before_init_callbacks << proc{ Factory.string }
-      block = Proc.new{ Factory.string }
-      subject.before_init(&block)
-      assert_equal block, subject.before_init_callbacks.last
-    end
-
-    should "append a block to the after init callbacks using `after_init`" do
-      subject.after_init_callbacks << proc{ Factory.string }
-      block = Proc.new{ Factory.string }
-      subject.after_init(&block)
-      assert_equal block, subject.after_init_callbacks.last
-    end
-
-    should "append a block to the before run callbacks using `before_run`" do
-      subject.before_run_callbacks << proc{ Factory.string }
-      block = Proc.new{ Factory.string }
-      subject.before_run(&block)
-      assert_equal block, subject.before_run_callbacks.last
-    end
-
-    should "append a block to the after run callbacks using `after_run`" do
-      subject.after_run_callbacks << proc{ Factory.string }
-      block = Proc.new{ Factory.string }
-      subject.after_run(&block)
-      assert_equal block, subject.after_run_callbacks.last
-    end
-
-    should "prepend a block to the before callbacks using `prepend_before`" do
-      subject.before_callbacks << proc{ Factory.string }
-      block = Proc.new{ Factory.string }
-      subject.prepend_before(&block)
-      assert_equal block, subject.before_callbacks.first
-    end
-
-    should "prepend a block to the after callbacks using `prepend_after`" do
-      subject.after_callbacks << proc{ Factory.string }
-      block = Proc.new{ Factory.string }
-      subject.prepend_after(&block)
-      assert_equal block, subject.after_callbacks.first
-    end
-
-    should "prepend a block to the before init callbacks using `prepend_before_init`" do
-      subject.before_init_callbacks << proc{ Factory.string }
-      block = Proc.new{ Factory.string }
-      subject.prepend_before_init(&block)
-      assert_equal block, subject.before_init_callbacks.first
-    end
-
-    should "prepend a block to the after init callbacks using `prepend_after_init`" do
-      subject.after_init_callbacks << proc{ Factory.string }
-      block = Proc.new{ Factory.string }
-      subject.prepend_after_init(&block)
-      assert_equal block, subject.after_init_callbacks.first
-    end
-
-    should "prepend a block to the before run callbacks using `prepend_before_run`" do
-      subject.before_run_callbacks << proc{ Factory.string }
-      block = Proc.new{ Factory.string }
-      subject.prepend_before_run(&block)
-      assert_equal block, subject.before_run_callbacks.first
-    end
-
-    should "prepend a block to the after run callbacks using `prepend_after_run`" do
-      subject.after_run_callbacks << proc{ Factory.string }
-      block = Proc.new{ Factory.string }
-      subject.prepend_after_run(&block)
-      assert_equal block, subject.after_run_callbacks.first
+    should "be a message handler" do
+      assert_includes Qs::MessageHandler, subject
     end
 
   end
@@ -147,46 +21,22 @@ module Qs::JobHandler
   class InitTests < UnitTests
     desc "when init"
     setup do
-      @runner = FakeRunner.new
+      @runner  = FakeRunner.new
       @handler = TestJobHandler.new(@runner)
     end
     subject{ @handler }
 
-    should have_imeths :init, :init!, :run, :run!
-
-    should "know its job, params and logger" do
-      assert_equal @runner.job,    subject.public_job
-      assert_equal @runner.params, subject.public_params
-      assert_equal @runner.logger, subject.public_logger
-    end
-
-    should "call `init!` and its before/after init callbacks using `init`" do
-      subject.init
-      assert_equal 1, subject.first_before_init_call_order
-      assert_equal 2, subject.second_before_init_call_order
-      assert_equal 3, subject.init_call_order
-      assert_equal 4, subject.first_after_init_call_order
-      assert_equal 5, subject.second_after_init_call_order
-    end
-
-    should "call `run!` and its before/after run callbacks using `run`" do
-      subject.run
-      assert_equal 1, subject.first_before_run_call_order
-      assert_equal 2, subject.second_before_run_call_order
-      assert_equal 3, subject.run_call_order
-      assert_equal 4, subject.first_after_run_call_order
-      assert_equal 5, subject.second_after_run_call_order
+    should "know its job, job name and job created at" do
+      assert_equal @runner.job,            subject.public_job
+      assert_equal @runner.job.name,       subject.public_job_name
+      assert_equal @runner.job.created_at, subject.public_job_created_at
     end
 
     should "have a custom inspect" do
       reference = '0x0%x' % (subject.object_id << 1)
-      expected = "#<#{subject.class}:#{reference} " \
-                 "@job=#{@handler.public_job.inspect}>"
-      assert_equal expected, subject.inspect
-    end
-
-    should "raise a not implemented error when `run!` by default" do
-      assert_raises(NotImplementedError){ @handler_class.new(@runner).run! }
+      exp = "#<#{subject.class}:#{reference} " \
+            "@job=#{@handler.public_job.inspect}>"
+      assert_equal exp, subject.inspect
     end
 
   end
@@ -194,51 +44,16 @@ module Qs::JobHandler
   class TestJobHandler
     include Qs::JobHandler
 
-    attr_reader :first_before_init_call_order, :second_before_init_call_order
-    attr_reader :first_after_init_call_order, :second_after_init_call_order
-    attr_reader :first_before_run_call_order, :second_before_run_call_order
-    attr_reader :first_after_run_call_order, :second_after_run_call_order
-    attr_reader :init_call_order, :run_call_order
-
-    before_init{ @first_before_init_call_order = next_call_order }
-    before_init{ @second_before_init_call_order = next_call_order }
-
-    after_init{ @first_after_init_call_order = next_call_order }
-    after_init{ @second_after_init_call_order = next_call_order }
-
-    before_run{ @first_before_run_call_order = next_call_order }
-    before_run{ @second_before_run_call_order = next_call_order }
-
-    after_run{ @first_after_run_call_order = next_call_order }
-    after_run{ @second_after_run_call_order = next_call_order }
-
-    def init!
-      @init_call_order = next_call_order
-    end
-
-    def run!
-      @run_call_order = next_call_order
-    end
-
-    def public_job;    job;    end
-    def public_params; params; end
-    def public_logger; logger; end
-
-    private
-
-    def next_call_order
-      @order ||= 0
-      @order += 1
-    end
+    def public_job;            job;            end
+    def public_job_name;       job_name;       end
+    def public_job_created_at; job_created_at; end
   end
 
   class FakeRunner
-    attr_accessor :job, :params, :logger
+    attr_accessor :job
 
     def initialize
-      @job    = Factory.job
-      @params = Factory.string
-      @logger = Factory.string
+      @job = Factory.job
     end
   end
 

--- a/test/unit/message_handler_tests.rb
+++ b/test/unit/message_handler_tests.rb
@@ -1,0 +1,235 @@
+require 'assert'
+require 'qs/message_handler'
+
+module Qs::MessageHandler
+
+  class UnitTests < Assert::Context
+    desc "Qs::MessageHandler"
+    setup do
+      @handler_class = Class.new{ include Qs::MessageHandler }
+    end
+    subject{ @handler_class }
+
+    should have_imeths :timeout
+    should have_imeths :before_callbacks, :after_callbacks
+    should have_imeths :before_init_callbacks, :after_init_callbacks
+    should have_imeths :before_run_callbacks,  :after_run_callbacks
+    should have_imeths :before, :after
+    should have_imeths :before_init, :after_init
+    should have_imeths :before_run,  :after_run
+    should have_imeths :prepend_before, :prepend_after
+    should have_imeths :prepend_before_init, :prepend_after_init
+    should have_imeths :prepend_before_run,  :prepend_after_run
+
+    should "allow reading/writing its timeout" do
+      assert_nil subject.timeout
+      value = Factory.integer
+      subject.timeout(value)
+      assert_equal value, subject.timeout
+    end
+
+    should "convert timeout values to floats" do
+      value = Factory.float.to_s
+      subject.timeout(value)
+      assert_equal value.to_f, subject.timeout
+    end
+
+    should "return an empty array by default using `before_callbacks`" do
+      assert_equal [], subject.before_callbacks
+    end
+
+    should "return an empty array by default using `after_callbacks`" do
+      assert_equal [], subject.after_callbacks
+    end
+
+    should "return an empty array by default using `before_init_callbacks`" do
+      assert_equal [], subject.before_init_callbacks
+    end
+
+    should "return an empty array by default using `after_init_callbacks`" do
+      assert_equal [], subject.after_init_callbacks
+    end
+
+    should "return an empty array by default using `before_run_callbacks`" do
+      assert_equal [], subject.before_run_callbacks
+    end
+
+    should "return an empty array by default using `after_run_callbacks`" do
+      assert_equal [], subject.after_run_callbacks
+    end
+
+    should "append a block to the before callbacks using `before`" do
+      subject.before_callbacks << proc{ Factory.string }
+      block = Proc.new{ Factory.string }
+      subject.before(&block)
+      assert_equal block, subject.before_callbacks.last
+    end
+
+    should "append a block to the after callbacks using `after`" do
+      subject.after_callbacks << proc{ Factory.string }
+      block = Proc.new{ Factory.string }
+      subject.after(&block)
+      assert_equal block, subject.after_callbacks.last
+    end
+
+    should "append a block to the before init callbacks using `before_init`" do
+      subject.before_init_callbacks << proc{ Factory.string }
+      block = Proc.new{ Factory.string }
+      subject.before_init(&block)
+      assert_equal block, subject.before_init_callbacks.last
+    end
+
+    should "append a block to the after init callbacks using `after_init`" do
+      subject.after_init_callbacks << proc{ Factory.string }
+      block = Proc.new{ Factory.string }
+      subject.after_init(&block)
+      assert_equal block, subject.after_init_callbacks.last
+    end
+
+    should "append a block to the before run callbacks using `before_run`" do
+      subject.before_run_callbacks << proc{ Factory.string }
+      block = Proc.new{ Factory.string }
+      subject.before_run(&block)
+      assert_equal block, subject.before_run_callbacks.last
+    end
+
+    should "append a block to the after run callbacks using `after_run`" do
+      subject.after_run_callbacks << proc{ Factory.string }
+      block = Proc.new{ Factory.string }
+      subject.after_run(&block)
+      assert_equal block, subject.after_run_callbacks.last
+    end
+
+    should "prepend a block to the before callbacks using `prepend_before`" do
+      subject.before_callbacks << proc{ Factory.string }
+      block = Proc.new{ Factory.string }
+      subject.prepend_before(&block)
+      assert_equal block, subject.before_callbacks.first
+    end
+
+    should "prepend a block to the after callbacks using `prepend_after`" do
+      subject.after_callbacks << proc{ Factory.string }
+      block = Proc.new{ Factory.string }
+      subject.prepend_after(&block)
+      assert_equal block, subject.after_callbacks.first
+    end
+
+    should "prepend a block to the before init callbacks using `prepend_before_init`" do
+      subject.before_init_callbacks << proc{ Factory.string }
+      block = Proc.new{ Factory.string }
+      subject.prepend_before_init(&block)
+      assert_equal block, subject.before_init_callbacks.first
+    end
+
+    should "prepend a block to the after init callbacks using `prepend_after_init`" do
+      subject.after_init_callbacks << proc{ Factory.string }
+      block = Proc.new{ Factory.string }
+      subject.prepend_after_init(&block)
+      assert_equal block, subject.after_init_callbacks.first
+    end
+
+    should "prepend a block to the before run callbacks using `prepend_before_run`" do
+      subject.before_run_callbacks << proc{ Factory.string }
+      block = Proc.new{ Factory.string }
+      subject.prepend_before_run(&block)
+      assert_equal block, subject.before_run_callbacks.first
+    end
+
+    should "prepend a block to the after run callbacks using `prepend_after_run`" do
+      subject.after_run_callbacks << proc{ Factory.string }
+      block = Proc.new{ Factory.string }
+      subject.prepend_after_run(&block)
+      assert_equal block, subject.after_run_callbacks.first
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @runner  = FakeRunner.new
+      @handler = TestMessageHandler.new(@runner)
+    end
+    subject{ @handler }
+
+    should have_imeths :init, :init!, :run, :run!
+
+    should "know its params and logger" do
+      assert_equal @runner.params, subject.public_params
+      assert_equal @runner.logger, subject.public_logger
+    end
+
+    should "call `init!` and its before/after init callbacks using `init`" do
+      subject.init
+      assert_equal 1, subject.first_before_init_call_order
+      assert_equal 2, subject.second_before_init_call_order
+      assert_equal 3, subject.init_call_order
+      assert_equal 4, subject.first_after_init_call_order
+      assert_equal 5, subject.second_after_init_call_order
+    end
+
+    should "call `run!` and its before/after run callbacks using `run`" do
+      subject.run
+      assert_equal 1, subject.first_before_run_call_order
+      assert_equal 2, subject.second_before_run_call_order
+      assert_equal 3, subject.run_call_order
+      assert_equal 4, subject.first_after_run_call_order
+      assert_equal 5, subject.second_after_run_call_order
+    end
+
+    should "raise a not implemented error when `run!` by default" do
+      assert_raises(NotImplementedError){ @handler_class.new(@runner).run! }
+    end
+
+  end
+
+  class TestMessageHandler
+    include Qs::MessageHandler
+
+    attr_reader :first_before_init_call_order, :second_before_init_call_order
+    attr_reader :first_after_init_call_order, :second_after_init_call_order
+    attr_reader :first_before_run_call_order, :second_before_run_call_order
+    attr_reader :first_after_run_call_order, :second_after_run_call_order
+    attr_reader :init_call_order, :run_call_order
+
+    before_init{ @first_before_init_call_order = next_call_order }
+    before_init{ @second_before_init_call_order = next_call_order }
+
+    after_init{ @first_after_init_call_order = next_call_order }
+    after_init{ @second_after_init_call_order = next_call_order }
+
+    before_run{ @first_before_run_call_order = next_call_order }
+    before_run{ @second_before_run_call_order = next_call_order }
+
+    after_run{ @first_after_run_call_order = next_call_order }
+    after_run{ @second_after_run_call_order = next_call_order }
+
+    def init!
+      @init_call_order = next_call_order
+    end
+
+    def run!
+      @run_call_order = next_call_order
+    end
+
+    def public_params; params; end
+    def public_logger; logger; end
+
+    private
+
+    def next_call_order
+      @order ||= 0
+      @order += 1
+    end
+  end
+
+  class FakeRunner
+    attr_accessor :params, :logger
+
+    def initialize
+      @params = Factory.string
+      @logger = Factory.string
+    end
+  end
+
+end


### PR DESCRIPTION
This adds a `MessageHandler`, moves most of the `JobHandler` logic
into it and then updates `JobHandler` and `EventHandler` to use
it. This is part of making events a kind of message and siblings to
jobs.

The `MessageHandler` contains all the handler-pattern logic for
initializing, the init/run methods and callbacks. It also provides
a params and logger method for all handlers. Both the job and event
handler can use this behavior and the event handler no longer has
to work with the job handlers behavior.

This also extends the job and event handler to provide additional
methods for easily reading their other attributes. These attributes
shouldn't be any harder to access than the params.

@kellyredding - Ready for review. This is mostly just copy-pasting the handler-pattern logic out of the `JobHandler`.