### PR TITLE
Update runners to expect a message

### DIFF
--- a/lib/qs/event_handler.rb
+++ b/lib/qs/event_handler.rb
@@ -8,8 +8,6 @@ module Qs
     def self.included(klass)
       klass.class_eval do
         include Qs::MessageHandler
-        # TODO - remove once runners are updated to handle messages
-        include Qs::JobHandler
         include InstanceMethods
       end
     end
@@ -18,7 +16,8 @@ module Qs
 
       def initialize(*args)
         super
-        @qs_event = Event.new(@qs_runner.job)
+        # TODO - remove once events are a kind of message
+        @qs_event = Event.new(@qs_runner.message)
       end
 
       def inspect
@@ -35,7 +34,7 @@ module Qs
       def event_name;         event.name;         end
       def event_published_at; event.published_at; end
 
-      # TODO - remove once runners are updated to handle messages
+      # TODO - remove once events are a kind of message
       def params; @qs_event.params; end
 
     end

--- a/lib/qs/event_handler_test_helpers.rb
+++ b/lib/qs/event_handler_test_helpers.rb
@@ -1,4 +1,4 @@
-require 'qs/job_test_runner'
+require 'qs/test_runner'
 
 module Qs::EventHandler
 

--- a/lib/qs/job_handler.rb
+++ b/lib/qs/job_handler.rb
@@ -22,9 +22,9 @@ module Qs
 
       # Helpers
 
-      def job;            @qs_runner.job; end
-      def job_name;       job.name;       end
-      def job_created_at; job.created_at; end
+      def job;            @qs_runner.message; end
+      def job_name;       job.name;           end
+      def job_created_at; job.created_at;     end
 
     end
 

--- a/lib/qs/job_handler_test_helpers.rb
+++ b/lib/qs/job_handler_test_helpers.rb
@@ -1,4 +1,4 @@
-require 'qs/job_test_runner'
+require 'qs/test_runner'
 
 module Qs::JobHandler
 

--- a/lib/qs/route.rb
+++ b/lib/qs/route.rb
@@ -16,11 +16,11 @@ module Qs
       @handler_class = constantize_handler_class(@handler_class_name)
     end
 
-    def run(job, daemon_data)
+    def run(message, daemon_data)
       QsRunner.new(self.handler_class, {
-        :job    => job,
-        :params => job.params,
-        :logger => daemon_data.logger
+        :message => message,
+        :params  => message.params,
+        :logger  => daemon_data.logger
       }).run
     end
 

--- a/lib/qs/runner.rb
+++ b/lib/qs/runner.rb
@@ -5,15 +5,15 @@ module Qs
   class Runner
 
     attr_reader :handler_class, :handler
-    attr_reader :job, :params, :logger
+    attr_reader :message, :params, :logger
 
     def initialize(handler_class, args = nil)
       @handler_class = handler_class
 
       a = args || {}
-      @job    = a[:job]
-      @params = a[:params] || {}
-      @logger = a[:logger] || Qs::NullLogger.new
+      @message = a[:message]
+      @params  = a[:params] || {}
+      @logger  = a[:logger] || Qs::NullLogger.new
 
       @handler = @handler_class.new(self)
     end

--- a/test/unit/event_handler_test_helpers_tests.rb
+++ b/test/unit/event_handler_test_helpers_tests.rb
@@ -2,7 +2,7 @@ require 'assert'
 require 'qs/event_handler_test_helpers'
 
 require 'qs/event_handler'
-require 'qs/job_test_runner'
+require 'qs/test_runner'
 require 'test/support/runner_spy'
 
 module Qs::EventHandler::TestHelpers

--- a/test/unit/event_handler_tests.rb
+++ b/test/unit/event_handler_tests.rb
@@ -2,7 +2,6 @@ require 'assert'
 require 'qs/event_handler'
 
 require 'qs/event'
-require 'qs/job_handler'
 require 'qs/message_handler'
 
 module Qs::EventHandler
@@ -18,10 +17,6 @@ module Qs::EventHandler
       assert_includes Qs::MessageHandler, subject
     end
 
-    should "be a job handler" do
-      assert_includes Qs::JobHandler, subject
-    end
-
   end
 
   class InitTests < UnitTests
@@ -33,16 +28,16 @@ module Qs::EventHandler
     subject{ @handler }
 
     should "know its event, channel, name and published at" do
-      event = Qs::Event.new(@runner.job)
+      event = Qs::Event.new(@runner.message)
       assert_equal event,              subject.public_event
       assert_equal event.channel,      subject.public_event_channel
       assert_equal event.name,         subject.public_event_name
       assert_equal event.published_at, subject.public_event_published_at
     end
 
-    # TODO - remove once runners are updated to handle messages
+    # TODO - remove once events are a kind of message
     should "know its params" do
-      event = Qs::Event.new(@runner.job)
+      event = Qs::Event.new(@runner.message)
       assert_equal event.params, subject.public_params
     end
 
@@ -68,10 +63,10 @@ module Qs::EventHandler
   end
 
   class FakeRunner
-    attr_accessor :job
+    attr_accessor :message
 
     def initialize
-      @job = Factory.event_job
+      @message = Factory.event_job
     end
   end
 

--- a/test/unit/job_handler_test_helper_tests.rb
+++ b/test/unit/job_handler_test_helper_tests.rb
@@ -2,7 +2,7 @@ require 'assert'
 require 'qs/job_handler_test_helpers'
 
 require 'qs/job_handler'
-require 'qs/job_test_runner'
+require 'qs/test_runner'
 require 'test/support/runner_spy'
 
 module Qs::JobHandler::TestHelpers

--- a/test/unit/job_handler_tests.rb
+++ b/test/unit/job_handler_tests.rb
@@ -27,9 +27,9 @@ module Qs::JobHandler
     subject{ @handler }
 
     should "know its job, job name and job created at" do
-      assert_equal @runner.job,            subject.public_job
-      assert_equal @runner.job.name,       subject.public_job_name
-      assert_equal @runner.job.created_at, subject.public_job_created_at
+      assert_equal @runner.message,               subject.public_job
+      assert_equal subject.public_job.name,       subject.public_job_name
+      assert_equal subject.public_job.created_at, subject.public_job_created_at
     end
 
     should "have a custom inspect" do
@@ -50,10 +50,10 @@ module Qs::JobHandler
   end
 
   class FakeRunner
-    attr_accessor :job
+    attr_accessor :message
 
     def initialize
-      @job = Factory.job
+      @message = Factory.job
     end
   end
 

--- a/test/unit/route_tests.rb
+++ b/test/unit/route_tests.rb
@@ -53,12 +53,12 @@ class Qs::Route
     should "build and run a qs runner" do
       assert_not_nil @runner_spy
       assert_equal @route.handler_class, @runner_spy.handler_class
-      expected = {
-        :job    => @job,
-        :params => @job.params,
-        :logger => @daemon_data.logger
+      exp = {
+        :message => @job,
+        :params  => @job.params,
+        :logger  => @daemon_data.logger
       }
-      assert_equal expected, @runner_spy.args
+      assert_equal exp, @runner_spy.args
       assert_true @runner_spy.run_called
     end
 

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -24,7 +24,7 @@ class Qs::Runner
     subject{ @runner }
 
     should have_readers :handler_class, :handler
-    should have_readers :job, :params, :logger
+    should have_readers :message, :params, :logger
     should have_imeths :run
 
     should "know its handler class and handler" do
@@ -33,21 +33,21 @@ class Qs::Runner
     end
 
     should "not set its job, params or logger by default" do
-      assert_nil subject.job
+      assert_nil subject.message
       assert_equal({}, subject.params)
       assert_instance_of Qs::NullLogger, subject.logger
     end
 
-    should "allow passing a job, params and logger" do
+    should "allow passing a message, params and logger" do
       args = {
-        :job    => Factory.string,
-        :params => Factory.string,
-        :logger => Factory.string
+        :message => Factory.string,
+        :params  => Factory.string,
+        :logger  => Factory.string
       }
       runner = @runner_class.new(@handler_class, args)
-      assert_equal args[:job],    runner.job
-      assert_equal args[:params], runner.params
-      assert_equal args[:logger], runner.logger
+      assert_equal args[:message], runner.message
+      assert_equal args[:params],  runner.params
+      assert_equal args[:logger],  runner.logger
     end
 
     should "raise a not implemented error when run" do


### PR DESCRIPTION
This updates the runners to expect to be passed a generic message.
This is part of making events a kind of message and siblings to
job.

For `Runner` and `QsRunner` this only involved renaming job to
message for the runners and handlers. No other functionality was
changed.

For the test runners, this adds a `TestRunner` for the common
logic between `JobTestRunner` and `EventTestRunner` and changes
`EventTestRunner` to inherit from it. This makes the test runners
siblings which is how jobs and events will eventually be. This
allows them to make use of the common logic for running an handler
in the test suite but also do custom logic as needed.

@kellyredding - Ready for review.