### PR TITLE
Update `Event` to be a kind of `Message`

### DIFF
--- a/bench/config.qs
+++ b/bench/config.qs
@@ -27,8 +27,8 @@ class BenchDaemon
 
   queue BenchQueue
 
-  # if jobs fail notify the bench report so it doesn't hang forever on IO.select
-  error do |exception, daemon_data, job|
+  # if fails notify the bench report so it doesn't hang forever on IO.select
+  error do |exception, context|
     PROGRESS_IO.write_nonblock('F')
   end
 

--- a/bench/report.txt
+++ b/bench/report.txt
@@ -5,7 +5,7 @@ Adding jobs
 Running jobs
 ....................................................................................................
 
-Adding 10000 Jobs Time:   1.4578s
-Running 10000 Jobs Time: 11.5084s
+Adding 10000 Jobs Time:   1.6360s
+Running 10000 Jobs Time: 11.1720s
 
 Done running benchmark report

--- a/lib/qs/client.rb
+++ b/lib/qs/client.rb
@@ -68,8 +68,8 @@ module Qs
       end
 
       def sync_subscriptions(queue)
-        event_subs_keys = queue.event_job_names.map do |event_job_name|
-          Qs::Event::SubscribersRedisKey.new(event_job_name)
+        event_subs_keys = queue.event_route_names.map do |route_name|
+          Qs::Event::SubscribersRedisKey.new(route_name)
         end
         redis_transaction do |c|
           event_subs_keys.each{ |key| c.sadd(key, queue.name) }

--- a/lib/qs/daemon_data.rb
+++ b/lib/qs/daemon_data.rb
@@ -5,7 +5,7 @@ module Qs
     # The daemon uses this to "compile" its configuration for speed. NsOptions
     # is relatively slow everytime an option is read. To avoid this, we read the
     # options one time here and memoize their values. This way, we don't pay the
-    # NsOptions overhead when reading them while handling a job.
+    # NsOptions overhead when reading them while handling a message.
 
     attr_reader :name
     attr_reader :pid_file

--- a/lib/qs/dispatch_job.rb
+++ b/lib/qs/dispatch_job.rb
@@ -16,7 +16,7 @@ module Qs
     end
 
     def event
-      @event ||= Qs::Event.build(
+      @event ||= Qs::Event.new(
         params['event_channel'],
         params['event_name'],
         params['event_params'],

--- a/lib/qs/event_handler.rb
+++ b/lib/qs/event_handler.rb
@@ -1,4 +1,3 @@
-require 'qs/event'
 require 'qs/message_handler'
 
 module Qs
@@ -14,12 +13,6 @@ module Qs
 
     module InstanceMethods
 
-      def initialize(*args)
-        super
-        # TODO - remove once events are a kind of message
-        @qs_event = Event.new(@qs_runner.message)
-      end
-
       def inspect
         reference = '0x0%x' % (self.object_id << 1)
         "#<#{self.class}:#{reference} @event=#{event.inspect}>"
@@ -29,13 +22,10 @@ module Qs
 
       # Helpers
 
-      def event;              @qs_event;          end
+      def event;              @qs_runner.message; end
       def event_channel;      event.channel;      end
       def event_name;         event.name;         end
       def event_published_at; event.published_at; end
-
-      # TODO - remove once events are a kind of message
-      def params; @qs_event.params; end
 
     end
 

--- a/lib/qs/job.rb
+++ b/lib/qs/job.rb
@@ -9,14 +9,11 @@ module Qs
     attr_reader :name, :created_at
 
     def initialize(name, params, options = nil)
-      options ||= {}
-      # TODO - remove once Event doesn't build Job
-      options[:type] = PAYLOAD_TYPE unless options.key?(:type)
       validate!(name, params)
+      options ||= {}
       @name       = name
       @created_at = options[:created_at] || Time.now
-      # TODO - change options[:type] to PAYLOAD_TYPE once Event doesn't build Job
-      super(options[:type], params)
+      super(PAYLOAD_TYPE, params)
     end
 
     def route_name

--- a/lib/qs/payload.rb
+++ b/lib/qs/payload.rb
@@ -1,31 +1,62 @@
 require 'qs'
+require 'qs/event'
 require 'qs/job'
 
 module Qs
 
   module Payload
 
+    PAYLOAD_TYPES = Hash.new{ |h, t| raise(InvalidError.new(t)) }.tap do |h|
+      h[Job::PAYLOAD_TYPE]   = 'job'
+      h[Event::PAYLOAD_TYPE] = 'event'
+    end.freeze
+
     def self.deserialize(encoded_payload)
-      self.job(Qs.decode(encoded_payload))
+      payload_hash = Qs.decode(encoded_payload)
+      self.send(PAYLOAD_TYPES[payload_hash['type']], payload_hash)
+    end
+
+    def self.serialize(message)
+      Qs.encode(self.send("#{PAYLOAD_TYPES[message.payload_type]}_hash", message))
     end
 
     def self.job(payload_hash)
       Qs::Job.new(payload_hash['name'], payload_hash['params'], {
-        :type       => payload_hash['type'],
-        :created_at => Time.at(payload_hash['created_at'].to_i)
+        :created_at => Timestamp.to_time(payload_hash['created_at'])
       })
     end
 
-    def self.serialize(message)
-      Qs.encode(self.job_hash(message))
+    def self.job_hash(job)
+      self.message_hash(job, {
+        'name'       => job.name.to_s,
+        'created_at' => Timestamp.new(job.created_at)
+      })
     end
 
-    def self.job_hash(job)
-      { 'type'       => job.payload_type.to_s,
-        'name'       => job.name.to_s,
-        'params'     => StringifyParams.new(job.params),
-        'created_at' => job.created_at.to_i
-      }
+    def self.event(payload_hash)
+      Qs::Event.new(
+        payload_hash['channel'],
+        payload_hash['name'],
+        payload_hash['params'],
+        { :published_at => Timestamp.to_time(payload_hash['published_at']) }
+      )
+    end
+
+    def self.event_hash(event)
+      self.message_hash(event, {
+        'channel'      => event.channel.to_s,
+        'name'         => event.name.to_s,
+        'published_at' => Timestamp.new(event.published_at)
+      })
+    end
+
+    # private
+
+    def self.message_hash(message, hash)
+      hash.tap do |h|
+        h['type']   = message.payload_type.to_s
+        h['params'] = StringifyParams.new(message.params)
+      end
     end
 
     module StringifyParams
@@ -38,6 +69,22 @@ module Qs
         else
           object
         end
+      end
+    end
+
+    module Timestamp
+      def self.to_time(integer)
+        Time.at(integer)
+      end
+
+      def self.new(time)
+        time.to_i
+      end
+    end
+
+    class InvalidError < ArgumentError
+      def initialize(payload_type)
+        super "unknown payload type #{payload_type.inspect}"
       end
     end
 

--- a/lib/qs/queue.rb
+++ b/lib/qs/queue.rb
@@ -5,13 +5,13 @@ module Qs
 
   class Queue
 
-    attr_reader :routes, :event_job_names
+    attr_reader :routes, :event_route_names
     attr_reader :enqueued_jobs
 
     def initialize(&block)
-      @routes          = []
-      @event_job_names = []
-      @enqueued_jobs   = []
+      @routes            = []
+      @event_route_names = []
+      @enqueued_jobs     = []
       self.instance_eval(&block) if !block.nil?
       raise InvalidError, "a queue must have a name" if self.name.nil?
     end
@@ -49,10 +49,10 @@ module Qs
         handler_name = "#{self.event_handler_ns}::#{handler_name}"
       end
 
-      job_name = Qs::Event::JobName.new(channel, name)
-      route_id = Qs::Message::RouteId.new(Qs::Event::PAYLOAD_TYPE, job_name)
+      route_name = Qs::Event::RouteName.new(channel, name)
+      route_id   = Qs::Message::RouteId.new(Qs::Event::PAYLOAD_TYPE, route_name)
 
-      @event_job_names.push(job_name)
+      @event_route_names.push(route_name)
       @routes.push(Qs::Route.new(route_id, handler_name))
     end
 

--- a/lib/qs/test_runner.rb
+++ b/lib/qs/test_runner.rb
@@ -1,5 +1,4 @@
 require 'qs'
-require 'qs/event'
 require 'qs/event_handler'
 require 'qs/job_handler'
 require 'qs/payload'
@@ -60,16 +59,7 @@ module Qs
       end
 
       args = (args || {}).dup
-      # TODO - change to this once events are a kind of message
-      # args[:message] = args.delete(:event) if args.key?(:event)
-      channel      = args.delete(:event_channel) || 'a-channel'
-      name         = args.delete(:event_name)    || 'a-name'
-      params       = args.delete(:params) || args.delete(:event_params) || {}
-      published_at = args.delete(:event_published_at)
-      args[:message] = Event.build(channel, name, params, {
-        :published_at => published_at
-      }).job
-      args[:params] = args[:message].params
+      args[:message] = args.delete(:event) if args.key?(:event)
       super(handler_class, args)
     end
 

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,4 +1,5 @@
 require 'assert/factory'
+require 'qs/dispatch_job'
 require 'qs/job'
 require 'qs/event'
 
@@ -14,7 +15,7 @@ module Factory
   end
 
   def self.message(params = nil)
-    self.send([:job, :event_job].choice, params)
+    self.send([:job, :event].choice, params)
   end
 
   def self.job(params = nil)
@@ -43,18 +44,18 @@ module Factory
     )
   end
 
-  def self.event_job(params = nil)
+  def self.event(params = nil)
     params ||= {}
     params[:channel]      ||= Factory.string
     params[:name]         ||= Factory.string
     params[:params]       ||= { Factory.string => Factory.string }
     params[:published_at] ||= Factory.time
-    Qs::Event.build(
+    Qs::Event.new(
       params.delete(:channel),
       params.delete(:name),
       params.delete(:params),
       params
-    ).job
+    )
   end
 
 end

--- a/test/unit/client_tests.rb
+++ b/test/unit/client_tests.rb
@@ -169,7 +169,7 @@ module Qs::Client
   class SyncSubscriptionsTests < RedisCallTests
     desc "sync_subscriptions"
     setup do
-      Factory.integer(3).times.map{ @queue.event_job_names << Factory.string }
+      Factory.integer(3).times.map{ @queue.event_route_names << Factory.string }
       subject.sync_subscriptions(@queue)
     end
 
@@ -180,9 +180,9 @@ module Qs::Client
 
     should "add the queue to each events subscribers" do
       calls = @connection_spy.redis_calls[2..-1]
-      assert_equal @queue.event_job_names.size, calls.size
+      assert_equal @queue.event_route_names.size, calls.size
       assert_equal [:sadd], calls.map(&:command).uniq
-      exp = @queue.event_job_names.map do |name|
+      exp = @queue.event_route_names.map do |name|
         [Qs::Event::SubscribersRedisKey.new(name), @queue.name]
       end
       assert_equal exp, calls.map(&:args)

--- a/test/unit/dispatch_job_tests.rb
+++ b/test/unit/dispatch_job_tests.rb
@@ -47,7 +47,7 @@ class Qs::DispatchJob
 
     should "know how to build an event from its params" do
       event = subject.event
-      exp = Qs::Event.build(
+      exp = Qs::Event.new(
         @event_channel,
         @event_name,
         @event_params,

--- a/test/unit/event_handler_tests.rb
+++ b/test/unit/event_handler_tests.rb
@@ -28,17 +28,10 @@ module Qs::EventHandler
     subject{ @handler }
 
     should "know its event, channel, name and published at" do
-      event = Qs::Event.new(@runner.message)
-      assert_equal event,              subject.public_event
-      assert_equal event.channel,      subject.public_event_channel
-      assert_equal event.name,         subject.public_event_name
-      assert_equal event.published_at, subject.public_event_published_at
-    end
-
-    # TODO - remove once events are a kind of message
-    should "know its params" do
-      event = Qs::Event.new(@runner.message)
-      assert_equal event.params, subject.public_params
+      assert_equal @runner.message,                   subject.public_event
+      assert_equal subject.public_event.channel,      subject.public_event_channel
+      assert_equal subject.public_event.name,         subject.public_event_name
+      assert_equal subject.public_event.published_at, subject.public_event_published_at
     end
 
     should "have a custom inspect" do
@@ -57,16 +50,13 @@ module Qs::EventHandler
     def public_event_channel;      event_channel;      end
     def public_event_name;         event_name;         end
     def public_event_published_at; event_published_at; end
-
-    # TODO - remove once runners are updated to handle messages
-    def public_params; params; end
   end
 
   class FakeRunner
     attr_accessor :message
 
     def initialize
-      @message = Factory.event_job
+      @message = Factory.event
     end
   end
 

--- a/test/unit/event_tests.rb
+++ b/test/unit/event_tests.rb
@@ -1,7 +1,7 @@
 require 'assert'
 require 'qs/event'
 
-require 'qs/job'
+require 'qs/message'
 
 class Qs::Event
 
@@ -17,28 +17,12 @@ class Qs::Event
     end
     subject{ @event_class }
 
-    should have_imeths :build
-
     should "know its payload type" do
       assert_equal 'event', PAYLOAD_TYPE
     end
 
-    should "build an event from args" do
-      event = subject.build(@channel, @name, @params, {
-        :published_at => @published_at
-      })
-      job = event.job
-
-      assert_instance_of Qs::Job, job
-      assert_equal PAYLOAD_TYPE, job.payload_type
-      assert_equal Qs::Event::JobName.new(@channel, @name), job.name
-      exp = {
-        'event_channel' => @channel,
-        'event_name'    => @name,
-        'event_params'  => @params
-      }
-      assert_equal exp, job.params
-      assert_equal @published_at, job.created_at
+    should "be a message" do
+      assert subject < Qs::Message
     end
 
   end
@@ -46,77 +30,93 @@ class Qs::Event
   class InitTests < UnitTests
     desc "when init"
     setup do
-      @job_params = {
-        'event_channel' => @channel,
-        'event_name'    => @name,
-        'event_params'  => @params
-      }
-      @job = Qs::Job.new(Factory.string, @job_params)
+      @current_time = Factory.time
+      Assert.stub(Time, :now).with{ @current_time }
 
-      @event = @event_class.new(@job)
+      @event = @event_class.new(@channel, @name, @params, {
+        :published_at => @published_at
+      })
     end
     subject{ @event }
 
-    should have_readers :job
-    should have_imeths :channel, :name, :params, :published_at
+    should have_readers :channel, :name, :published_at
+    should have_imeths :route_name
 
-    should "know its job" do
-      assert_equal @job, subject.job
+    should "know its attributes" do
+      assert_equal PAYLOAD_TYPE,  subject.payload_type
+      assert_equal @channel,      subject.channel
+      assert_equal @name,         subject.name
+      assert_equal @params,       subject.params
+      assert_equal @published_at, subject.published_at
     end
 
-    should "know its channel, name, params and published at" do
-      assert_equal @job.params['event_channel'], subject.channel
-      assert_equal @job.params['event_name'],    subject.name
-      assert_equal @job.params['event_params'],  subject.params
-      assert_equal @job.created_at,              subject.published_at
+    should "default its published at to the current time" do
+      event = @event_class.new(@channel, @name, @params)
+      assert_equal @current_time, event.published_at
     end
 
-    should "raise an error when given an invalid job" do
-      job_params = @job_params.dup
-      job_params.delete('event_channel')
-      job = Qs::Job.new(Factory.string, job_params)
-      assert_raises(Qs::BadEventError){ @event_class.new(job) }
-
-      job_params = @job_params.dup
-      job_params.delete('event_name')
-      job = Qs::Job.new(Factory.string, job_params)
-      assert_raises(Qs::BadEventError){ @event_class.new(job) }
-
-      job_params = @job_params.dup
-      job_params.delete('event_params')
-      job = Qs::Job.new(Factory.string, job_params)
-      assert_raises(Qs::BadEventError){ @event_class.new(job) }
+    should "know its route name" do
+      exp = RouteName.new(@channel, @name)
+      result = subject.route_name
+      assert_equal exp, result
+      assert_same result, subject.route_name
     end
 
     should "have a custom inspect" do
       reference = '0x0%x' % (subject.object_id << 1)
-      expected = "#<Qs::Event:#{reference} " \
-                 "@channel=#{subject.channel.inspect} " \
-                 "@name=#{subject.name.inspect} " \
-                 "@params=#{subject.params.inspect} " \
-                 "@published_at=#{subject.published_at.inspect}>"
-      assert_equal expected, subject.inspect
+      exp = "#<Qs::Event:#{reference} " \
+            "@channel=#{subject.channel.inspect} " \
+            "@name=#{subject.name.inspect} " \
+            "@params=#{subject.params.inspect} " \
+            "@published_at=#{subject.published_at.inspect}>"
+      assert_equal exp, subject.inspect
     end
 
     should "be comparable" do
-      other_job   = Qs::Job.new(Factory.string, @job_params)
-      other_event = @event_class.new(other_job)
+      matching = @event_class.new(@channel, @name, @params, {
+        :published_at => @published_at
+      })
+      assert_equal matching, subject
 
-      Assert.stub(other_job, :==).with(subject.job){ true }
-      assert_equal other_event, subject
-      Assert.stub(other_job, :==).with(subject.job){ false }
-      assert_not_equal other_event, subject
+      non_matching = @event_class.new(Factory.string, @name, @params, {
+        :published_at => @published_at
+      })
+      assert_not_equal non_matching, subject
+      non_matching = @event_class.new(@channel, Factory.string, @params, {
+        :published_at => @published_at
+      })
+      assert_not_equal non_matching, subject
+      other_params = { Factory.string => Factory.string }
+      non_matching = @event_class.new(@channel, @name, other_params, {
+        :published_at => @published_at
+      })
+      assert_not_equal non_matching, subject
+      non_matching = @event_class.new(@channel, @name, @params, {
+        :published_at => Factory.time
+      })
+      assert_not_equal non_matching, subject
+    end
+
+    should "raise an error when given invalid attributes" do
+      assert_raises(Qs::BadEventError){ @event_class.new(nil, @name, @params) }
+      assert_raises(Qs::BadEventError) do
+        @event_class.new(@channel, nil, @params)
+      end
+      assert_raises(Qs::BadEventError) do
+        @event_class.new(@channel, @name, Factory.string)
+      end
+      assert_raises(Qs::BadEventError){ @event_class.new(@channel, @name, nil) }
     end
 
   end
 
-  class JobNameTests < UnitTests
-    desc "JobName"
-    subject{ JobName }
+  class RouteNameTests < UnitTests
+    desc "RouteName"
+    subject{ RouteName }
 
     should have_imeths :new
 
-    should "return an event job name given an event channel and event name" do
+    should "return an event route name given an event channel and event name" do
       assert_equal "#{@channel}:#{@name}", subject.new(@channel, @name)
     end
 
@@ -128,10 +128,10 @@ class Qs::Event
 
     should have_imeths :new
 
-    should "return an event subscribers redis key given an event job name" do
-      event_job_name = JobName.new(@channel, @name)
-      exp = "events:#{event_job_name}:subscribers"
-      assert_equal exp, subject.new(event_job_name)
+    should "return an event subscribers redis key given an event route name" do
+      event_route_name = RouteName.new(@channel, @name)
+      exp = "events:#{event_route_name}:subscribers"
+      assert_equal exp, subject.new(event_route_name)
     end
 
   end

--- a/test/unit/payload_tests.rb
+++ b/test/unit/payload_tests.rb
@@ -10,45 +10,80 @@ module Qs::Payload
       # string can be randomly ordered
       Assert.stub(Qs, :encode){ |hash| hash.to_a.sort }
       Assert.stub(Qs, :decode){ |array| Hash[array] }
-
-      @job = Factory.job
     end
     subject{ Qs::Payload }
 
-    should have_imeths :deserialize, :job
-    should have_imeths :serialize, :job_hash
+    should have_imeths :deserialize, :serialize
+    should have_imeths :job, :job_hash
+    should have_imeths :event, :event_hash
 
-    should "serialize and deserialize jobs" do
-      encoded_payload = subject.serialize(@job)
-      exp = Qs.encode(subject.job_hash(@job))
+    should "serialize and deserialize messages" do
+      message = Factory.message
+      encoded_payload = subject.serialize(message)
+      exp = Qs.encode(subject.send("#{message.payload_type}_hash", message))
       assert_equal exp, encoded_payload
       deserialized_job = subject.deserialize(encoded_payload)
-      assert_equal @job, deserialized_job
+      assert_equal message, deserialized_job
     end
 
-    should "build jobs and payload hashes" do
+    should "build jobs and job payload hashes" do
+      job = Factory.job
       payload_hash = {
-        'type'       => @job.payload_type,
-        'name'       => @job.name,
-        'params'     => @job.params,
-        'created_at' => @job.created_at.to_i
+        'type'       => job.payload_type,
+        'name'       => job.name,
+        'params'     => job.params,
+        'created_at' => Timestamp.new(job.created_at)
       }
-      assert_equal @job, subject.job(payload_hash)
-      assert_equal payload_hash, subject.job_hash(@job)
+      assert_equal job, subject.job(payload_hash)
+      assert_equal payload_hash, subject.job_hash(job)
     end
 
-    should "sanitize its jobs attributes when building a payload hash" do
+    should "sanitize its jobs attributes when building a job payload hash" do
       job = Factory.job({
-        :type   => Factory.string.to_sym,
         :name   => Factory.string.to_sym,
         :params => { Factory.string.to_sym => Factory.string }
       })
       payload_hash = subject.job_hash(job)
 
-      assert_equal job.payload_type.to_s, payload_hash['type']
       assert_equal job.name.to_s, payload_hash['name']
       exp = StringifyParams.new(job.params)
       assert_equal exp, payload_hash['params']
+    end
+
+    should "build events and event payload hashes" do
+      event = Factory.event
+      payload_hash = {
+        'type'         => event.payload_type,
+        'channel'      => event.channel,
+        'name'         => event.name,
+        'params'       => event.params,
+        'published_at' => Timestamp.new(event.published_at)
+      }
+      assert_equal event, subject.event(payload_hash)
+      assert_equal payload_hash, subject.event_hash(event)
+    end
+
+    should "sanitize its events attributes when building an event payload hash" do
+      event = Factory.event({
+        :channel => Factory.string.to_sym,
+        :name    => Factory.string.to_sym,
+        :params  => { Factory.string.to_sym => Factory.string }
+      })
+      payload_hash = subject.event_hash(event)
+
+      assert_equal event.channel.to_s, payload_hash['channel']
+      assert_equal event.name.to_s,    payload_hash['name']
+      exp = StringifyParams.new(event.params)
+      assert_equal exp, payload_hash['params']
+    end
+
+    should "raise errors for unknown parent types" do
+      message = Factory.message
+      Assert.stub(message, :payload_type){ Factory.string }
+      payload_hash = { 'type' => message.payload_type }
+
+      assert_raises(InvalidError){ subject.deserialize(payload_hash) }
+      assert_raises(InvalidError){ subject.serialize(message) }
     end
 
   end
@@ -72,6 +107,21 @@ module Qs::Payload
         'array'  => [{ key.to_s => value }]
       }
       assert_equal exp, result
+    end
+
+  end
+
+  class TimestampTests < UnitTests
+    desc "Timestamp"
+    subject{ Timestamp }
+
+    should have_imeths :to_time, :new
+
+    should "handle building timestamps and converting them to times" do
+      time = Factory.time
+      timestamp = subject.new(time)
+      assert_equal time.to_i, timestamp
+      assert_equal time, subject.to_time(timestamp)
     end
 
   end

--- a/test/unit/qs_runner_tests.rb
+++ b/test/unit/qs_runner_tests.rb
@@ -2,7 +2,7 @@ require 'assert'
 require 'qs/qs_runner'
 
 require 'qs'
-require 'qs/job_handler'
+require 'qs/message_handler'
 
 class Qs::QsRunner
 
@@ -27,7 +27,7 @@ class Qs::QsRunner
   class InitTests < UnitTests
     desc "when init"
     setup do
-      @handler_class = TestJobHandler
+      @handler_class = TestMessageHandler
       @runner = @runner_class.new(@handler_class)
     end
     subject{ @runner }
@@ -36,8 +36,8 @@ class Qs::QsRunner
     should have_imeths :run
 
     should "know its timeout" do
-      assert_equal TestJobHandler.timeout, subject.timeout
-      handler_class = Class.new{ include Qs::JobHandler }
+      assert_equal TestMessageHandler.timeout, subject.timeout
+      handler_class = Class.new{ include Qs::MessageHandler }
       runner = @runner_class.new(handler_class)
       assert_equal Qs.config.timeout, runner.timeout
     end
@@ -131,8 +131,8 @@ class Qs::QsRunner
 
   end
 
-  class TestJobHandler
-    include Qs::JobHandler
+  class TestMessageHandler
+    include Qs::MessageHandler
 
     attr_reader :first_before_call_order, :second_before_call_order
     attr_reader :first_after_call_order, :second_after_call_order

--- a/test/unit/queue_tests.rb
+++ b/test/unit/queue_tests.rb
@@ -12,7 +12,7 @@ class Qs::Queue
     end
     subject{ @queue }
 
-    should have_readers :routes, :event_job_names, :enqueued_jobs
+    should have_readers :routes, :event_route_names, :enqueued_jobs
     should have_imeths :name, :redis_key
     should have_imeths :job_handler_ns, :job
     should have_imeths :event_handler_ns, :event
@@ -20,9 +20,9 @@ class Qs::Queue
     should have_imeths :sync_subscriptions, :clear_subscriptions
     should have_imeths :published_events, :reset!
 
-    should "default its routes, event job names and enqueued jobs" do
+    should "default its routes, event route names and enqueued jobs" do
       assert_equal [], subject.routes
-      assert_equal [], subject.event_job_names
+      assert_equal [], subject.event_route_names
       assert_equal [], subject.enqueued_jobs
     end
 
@@ -103,8 +103,8 @@ class Qs::Queue
 
       route = subject.routes.last
       assert_instance_of Qs::Route, route
-      job_name = Qs::Event::JobName.new(event_channel, event_name)
-      exp = Qs::Message::RouteId.new(Qs::Event::PAYLOAD_TYPE, job_name)
+      route_name = Qs::Event::RouteName.new(event_channel, event_name)
+      exp = Qs::Message::RouteId.new(Qs::Event::PAYLOAD_TYPE, route_name)
       assert_equal exp, route.id
       assert_equal handler_name, route.handler_class_name
     end
@@ -136,14 +136,14 @@ class Qs::Queue
       assert_equal handler_name, route.handler_class_name
     end
 
-    should "track its configured event job names" do
+    should "track its configured event route names" do
       event_channel = Factory.string
       event_name    = Factory.string
       handler_name  = Factory.string
       subject.event event_channel, event_name, handler_name
 
-      exp = Qs::Event::JobName.new(event_channel, event_name)
-      assert_equal [exp], subject.event_job_names
+      exp = Qs::Event::RouteName.new(event_channel, event_name)
+      assert_equal [exp], subject.event_route_names
     end
 
     should "return the enqueued jobs events using `published_events`" do

--- a/test/unit/route_tests.rb
+++ b/test/unit/route_tests.rb
@@ -3,7 +3,6 @@ require 'qs/route'
 
 require 'qs/daemon_data'
 require 'qs/logger'
-require 'qs/job'
 require 'test/support/runner_spy'
 
 class Qs::Route
@@ -39,7 +38,7 @@ class Qs::Route
   class RunTests < UnitTests
     desc "when run"
     setup do
-      @job = Qs::Job.new(Factory.string, Factory.string => Factory.string)
+      @message = Factory.message
       @daemon_data = Qs::DaemonData.new(:logger => Qs::NullLogger.new)
 
       @runner_spy = nil
@@ -47,15 +46,15 @@ class Qs::Route
         @runner_spy = RunnerSpy.new(*args)
       end
 
-      @route.run(@job, @daemon_data)
+      @route.run(@message, @daemon_data)
     end
 
     should "build and run a qs runner" do
       assert_not_nil @runner_spy
       assert_equal @route.handler_class, @runner_spy.handler_class
       exp = {
-        :message => @job,
-        :params  => @job.params,
+        :message => @message,
+        :params  => @message.params,
         :logger  => @daemon_data.logger
       }
       assert_equal exp, @runner_spy.args

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -32,7 +32,7 @@ class Qs::Runner
       assert_instance_of @handler_class, subject.handler
     end
 
-    should "not set its job, params or logger by default" do
+    should "not set its message, params or logger by default" do
       assert_nil subject.message
       assert_equal({}, subject.params)
       assert_instance_of Qs::NullLogger, subject.logger


### PR DESCRIPTION
This updates `Event` to be a kind of `Message` and makes it a
sibling of `Job`. This is to avoid extra logic working with events
when they composed jobs. This streamlines their handling and
makes them as similar as possible to jobs.

This updates the `Payload` to handle different types of payloads.
It will now use `send` and the payload type to either build a
job/event or their respective payload hashes. To handle unknown
payload types, if this generates an error, it will be rescued
and an invalid payload type error will be raised if the type
isn't one of the two valid types. This allows us to avoid a
conditional checking the type but also try and provide good errors
for most situations.

This also renames usage of job where message is now more
applicable. This was mostly comments but includes a few logs and
variables as well.

@kellyredding - Ready for review. This should be the big picture so far: https://github.com/redding/qs/compare/2982bd1ac98cd56fcfcf1e4778d7c4380f66fb39...jcr-event-inherit-message