### PR TITLE
Rename `RedisItem` to `QueueItem`

### DIFF
--- a/lib/qs/queue_item.rb
+++ b/lib/qs/queue_item.rb
@@ -1,6 +1,6 @@
 module Qs
 
-  class RedisItem
+  class QueueItem
 
     attr_reader :queue_redis_key, :encoded_payload
     attr_accessor :started, :finished

--- a/test/system/daemon_tests.rb
+++ b/test/system/daemon_tests.rb
@@ -168,8 +168,8 @@ module Qs::Daemon
 
   end
 
-  class ShutdownWithUnprocessedRedisItemTests < SystemTests
-    desc "with a redis item that gets picked up but doesn't get processed"
+  class ShutdownWithUnprocessedQueueItemTests < SystemTests
+    desc "with a queue item that gets picked up but doesn't get processed"
     setup do
       Assert.stub(Qs::PayloadHandler, :new){ sleep 5 }
 
@@ -185,7 +185,7 @@ module Qs::Daemon
       @thread.join 1 # let the daemon have time to process jobs
     end
 
-    should "shutdown and requeue the redis item" do
+    should "shutdown and requeue the queue item" do
       @daemon.stop
       @thread.join 2 # give it time to shutdown, should be faster
       assert_false @thread.alive?
@@ -195,7 +195,7 @@ module Qs::Daemon
       assert_equal ['basic', 'slow', 'slow'], names
     end
 
-    should "shutdown and requeue the redis item" do
+    should "shutdown and requeue the queue item" do
       @daemon.halt
       @thread.join 2 # give it time to shutdown, should be faster
       assert_false @thread.alive?

--- a/test/unit/queue_item_tests.rb
+++ b/test/unit/queue_item_tests.rb
@@ -1,18 +1,18 @@
 require 'assert'
-require 'qs/redis_item'
+require 'qs/queue_item'
 
 require 'qs/queue'
 
-class Qs::RedisItem
+class Qs::QueueItem
 
   class UnitTests < Assert::Context
-    desc "Qs::RedisItem"
+    desc "Qs::QueueItem"
     setup do
       @queue_redis_key = Factory.string
       @encoded_payload = Factory.string
-      @redis_item = Qs::RedisItem.new(@queue_redis_key, @encoded_payload)
+      @queue_item = Qs::QueueItem.new(@queue_redis_key, @encoded_payload)
     end
-    subject{ @redis_item }
+    subject{ @queue_item }
 
     should have_readers :queue_redis_key, :encoded_payload
     should have_accessors :started, :finished
@@ -35,14 +35,14 @@ class Qs::RedisItem
     end
 
     should "know if it equals another item" do
-      exp = Qs::RedisItem.new(@queue_redis_key, @encoded_payload)
+      exp = Qs::QueueItem.new(@queue_redis_key, @encoded_payload)
       assert_equal exp, subject
 
       redis_key = Qs::Queue::RedisKey.new(Factory.string)
-      exp = Qs::RedisItem.new(redis_key, @encoded_payload)
+      exp = Qs::QueueItem.new(redis_key, @encoded_payload)
       assert_not_equal exp, subject
 
-      exp = Qs::RedisItem.new(@queue_redis_key, Factory.string)
+      exp = Qs::QueueItem.new(@queue_redis_key, Factory.string)
       assert_not_equal exp, subject
     end
 


### PR DESCRIPTION
This renames the `RedisItem` to `QueueItem`. This is a better
naming than redis because it doesn't have anything specific to
redis. This doesn't change any functionality, it just renames the
class and local variables.

@kellyredding - Ready for review.