### PR TITLE
Pass params via options when building jobs and events

### DIFF
--- a/lib/qs/client.rb
+++ b/lib/qs/client.rb
@@ -31,21 +31,24 @@ module Qs
         @redis_config = redis_config
       end
 
-      def enqueue(queue, job_name, params = nil)
-        job = Qs::Job.new(job_name, params || {})
+      def enqueue(queue, job_name, job_params = nil)
+        job = Qs::Job.new(job_name, :params => job_params)
         enqueue!(queue, job)
         job
       end
 
       def publish(channel, name, params = nil)
-        publish!(channel, name, params)
+        publish!(channel, name, :event_params => params)
       end
 
       def publish_as(publisher, channel, name, params = nil)
-        publish!(channel, name, params, :event_publisher => publisher)
+        publish!(channel, name, {
+          :event_params    => params,
+          :event_publisher => publisher,
+        })
       end
 
-      def push(queue_name, payload)
+      def push(queue_name, payload_hash)
         raise NotImplementedError
       end
 
@@ -89,8 +92,8 @@ module Qs
 
       private
 
-      def publish!(channel, name, params = nil, options = nil)
-        dispatch_job = DispatchJob.new(channel, name, params || {}, options)
+      def publish!(channel, name, options = nil)
+        dispatch_job = DispatchJob.new(channel, name, options)
         enqueue!(Qs.dispatcher_queue, dispatch_job)
         dispatch_job.event
       end

--- a/lib/qs/dispatch_job.rb
+++ b/lib/qs/dispatch_job.rb
@@ -6,27 +6,25 @@ module Qs
 
   class DispatchJob < Qs::Job
 
-    def initialize(event_channel, event_name, event_params, options = nil)
+    def initialize(event_channel, event_name, options = nil)
       options ||= {}
+      event_params    = options.delete(:event_params)    || {}
       event_publisher = options.delete(:event_publisher) || Qs.event_publisher
-      params = {
+      options[:params] = {
         'event_channel'   => event_channel,
         'event_name'      => event_name,
         'event_params'    => event_params,
         'event_publisher' => event_publisher
       }
-      super(Qs.dispatcher_job_name, params, options)
+      super(Qs.dispatcher_job_name, options)
     end
 
     def event
-      @event ||= Qs::Event.new(
-        params['event_channel'],
-        params['event_name'],
-        params['event_params'],
-        { :publisher    => params['event_publisher'],
-          :published_at => self.created_at
-        }
-      )
+      @event ||= Qs::Event.new(params['event_channel'], params['event_name'], {
+        :params       => params['event_params'],
+        :publisher    => params['event_publisher'],
+        :published_at => self.created_at
+      })
     end
 
   end

--- a/lib/qs/event.rb
+++ b/lib/qs/event.rb
@@ -8,14 +8,15 @@ module Qs
 
     attr_reader :channel, :name, :publisher, :published_at
 
-    def initialize(channel, name, params, options = nil)
-      validate!(channel, name, params)
+    def initialize(channel, name, options = nil)
       options ||= {}
+      options[:params] ||= {}
+      validate!(channel, name, options[:params])
       @channel      = channel
       @name         = name
       @publisher    = options[:publisher]
       @published_at = options[:published_at] || Time.now
-      super(PAYLOAD_TYPE, params)
+      super(PAYLOAD_TYPE, options)
     end
 
     def route_name
@@ -55,7 +56,7 @@ module Qs
       elsif !params.kind_of?(::Hash)
         "The event's params are not valid."
       end
-      raise(BadEventError, problem) if problem
+      raise(InvalidError, problem) if problem
     end
 
     module RouteName
@@ -70,8 +71,8 @@ module Qs
       end
     end
 
-  end
+    InvalidError = Class.new(ArgumentError)
 
-  BadEventError = Class.new(ArgumentError)
+  end
 
 end

--- a/lib/qs/job.rb
+++ b/lib/qs/job.rb
@@ -8,12 +8,13 @@ module Qs
 
     attr_reader :name, :created_at
 
-    def initialize(name, params, options = nil)
-      validate!(name, params)
+    def initialize(name, options = nil)
       options ||= {}
+      options[:params] ||= {}
+      validate!(name, options[:params])
       @name       = name
       @created_at = options[:created_at] || Time.now
-      super(PAYLOAD_TYPE, params)
+      super(PAYLOAD_TYPE, options)
     end
 
     def route_name
@@ -47,11 +48,11 @@ module Qs
       elsif !params.kind_of?(::Hash)
         "The job's params are not valid."
       end
-      raise(BadJobError, problem) if problem
+      raise(InvalidError, problem) if problem
     end
 
-  end
+    InvalidError = Class.new(ArgumentError)
 
-  BadJobError = Class.new(ArgumentError)
+  end
 
 end

--- a/lib/qs/message.rb
+++ b/lib/qs/message.rb
@@ -4,9 +4,10 @@ module Qs
 
     attr_reader :payload_type, :params
 
-    def initialize(payload_type, params = nil)
+    def initialize(payload_type, options = nil)
+      options ||= {}
       @payload_type = payload_type.to_s
-      @params       = params || {}
+      @params       = options[:params] || {}
     end
 
     def route_id

--- a/lib/qs/payload.rb
+++ b/lib/qs/payload.rb
@@ -21,7 +21,8 @@ module Qs
     end
 
     def self.job(payload_hash)
-      Qs::Job.new(payload_hash['name'], payload_hash['params'], {
+      Qs::Job.new(payload_hash['name'], {
+        :params     => payload_hash['params'],
         :created_at => Timestamp.to_time(payload_hash['created_at'])
       })
     end
@@ -34,13 +35,11 @@ module Qs
     end
 
     def self.event(payload_hash)
-      Qs::Event.new(
-        payload_hash['channel'],
-        payload_hash['name'],
-        payload_hash['params'],
-        { :publisher    => payload_hash['publisher'],
-          :published_at => Timestamp.to_time(payload_hash['published_at']) }
-      )
+      Qs::Event.new(payload_hash['channel'], payload_hash['name'], {
+        :params       => payload_hash['params'],
+        :publisher    => payload_hash['publisher'],
+        :published_at => Timestamp.to_time(payload_hash['published_at'])
+      })
     end
 
     def self.event_hash(event)

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -18,45 +18,31 @@ module Factory
     self.send([:job, :event].choice, params)
   end
 
-  def self.job(params = nil)
-    params ||= {}
-    params[:name]       ||= Factory.string
-    params[:params]     ||= { Factory.string => Factory.string }
-    params[:created_at] ||= Factory.time
-    Qs::Job.new(
-      params.delete(:name),
-      params.delete(:params),
-      params
-    )
+  def self.job(args = nil)
+    args ||= {}
+    name = args.delete(:name) || Factory.string
+    args[:params]     ||= { Factory.string => Factory.string }
+    args[:created_at] ||= Factory.time
+    Qs::Job.new(name, args)
   end
 
-  def self.dispatch_job(params = nil)
-    params ||= {}
-    params[:event_channel] ||= Factory.string
-    params[:event_name]    ||= Factory.string
-    params[:event_params]  ||= { Factory.string => Factory.string }
-    params[:created_at]    ||= Factory.time
-    Qs::DispatchJob.new(
-      params.delete(:event_channel),
-      params.delete(:event_name),
-      params.delete(:event_params),
-      params
-    )
+  def self.dispatch_job(args = nil)
+    args ||= {}
+    event_channel = args.delete(:event_channel) || Factory.string
+    event_name    = args.delete(:event_name)    || Factory.string
+    args[:event_params] ||= { Factory.string => Factory.string }
+    args[:created_at]   ||= Factory.time
+    Qs::DispatchJob.new(event_channel, event_name, args)
   end
 
-  def self.event(params = nil)
-    params ||= {}
-    params[:channel]      ||= Factory.string
-    params[:name]         ||= Factory.string
-    params[:params]       ||= { Factory.string => Factory.string }
-    params[:publisher]    ||= Factory.string
-    params[:published_at] ||= Factory.time
-    Qs::Event.new(
-      params.delete(:channel),
-      params.delete(:name),
-      params.delete(:params),
-      params
-    )
+  def self.event(args = nil)
+    args ||= {}
+    channel = args.delete(:channel) || Factory.string
+    name    = args.delete(:name)    || Factory.string
+    args[:params]       ||= { Factory.string => Factory.string }
+    args[:publisher]    ||= Factory.string
+    args[:published_at] ||= Factory.time
+    Qs::Event.new(channel, name, args)
   end
 
 end

--- a/test/unit/client_tests.rb
+++ b/test/unit/client_tests.rb
@@ -71,12 +71,6 @@ module Qs::Client
       assert_equal call.job,    result
     end
 
-    should "default the job's params to an empty hash using `enqueue`" do
-      subject.enqueue(@queue, @job_name)
-      call = subject.enqueue_calls.last
-      assert_equal({}, call.job.params)
-    end
-
     should "enqueue a dispatch job and return its event using `publish`" do
       event_channel = Factory.string
       event_name    = Factory.string
@@ -94,15 +88,6 @@ module Qs::Client
       assert_equal dispatch_job.name,   call.job.name
       assert_equal dispatch_job.params, call.job.params
       assert_equal call.job.event,      result
-    end
-
-    should "default the dispatch job event params to an empty hash using `publish`" do
-      event_channel = Factory.string
-      event_name    = Factory.string
-      subject.publish(event_channel, event_name)
-
-      call = subject.enqueue_calls.last
-      assert_equal({}, call.job.params['event_params'])
     end
 
     should "enqueue a dispatch job with a custom publisher using `publish_as`" do

--- a/test/unit/dispatch_job_tests.rb
+++ b/test/unit/dispatch_job_tests.rb
@@ -27,7 +27,8 @@ class Qs::DispatchJob
       @event_params    = { Factory.string => Factory.string }
       @event_publisher = Factory.string
       @created_at      = Factory.time
-      @job = @job_class.new(@event_channel, @event_name, @event_params, {
+      @job = @job_class.new(@event_channel, @event_name, {
+        :event_params    => @event_params,
         :event_publisher => @event_publisher,
         :created_at      => @created_at
       })
@@ -51,22 +52,20 @@ class Qs::DispatchJob
       assert_equal @created_at, subject.created_at
     end
 
-    should "default its event publisher" do
+    should "default its event params and event publisher" do
       Qs.config.event_publisher = Factory.string
-      job = @job_class.new(@event_channel, @event_name, @event_params)
+      job = @job_class.new(@event_channel, @event_name)
+      assert_equal({}, job.params['event_params'])
       assert_equal Qs.event_publisher, job.params['event_publisher']
     end
 
     should "know how to build an event from its params" do
       event = subject.event
-      exp = Qs::Event.new(
-        @event_channel,
-        @event_name,
-        @event_params,
-        { :publisher    => @event_publisher,
-          :published_at => @created_at
-        }
-      )
+      exp = Qs::Event.new(@event_channel, @event_name, {
+        :params       => @event_params,
+        :publisher    => @event_publisher,
+        :published_at => @created_at
+      })
       assert_equal exp, event
       assert_same event, subject.event
     end

--- a/test/unit/event_tests.rb
+++ b/test/unit/event_tests.rb
@@ -34,7 +34,8 @@ class Qs::Event
       @current_time = Factory.time
       Assert.stub(Time, :now).with{ @current_time }
 
-      @event = @event_class.new(@channel, @name, @params, {
+      @event = @event_class.new(@channel, @name, {
+        :params       => @params,
         :publisher    => @publisher,
         :published_at => @published_at
       })
@@ -53,8 +54,9 @@ class Qs::Event
       assert_equal @published_at, subject.published_at
     end
 
-    should "default its published at to the current time" do
-      event = @event_class.new(@channel, @name, @params)
+    should "default its params and published at to the current time" do
+      event = @event_class.new(@channel, @name)
+      assert_equal({}, event.params)
       assert_equal @current_time, event.published_at
     end
 
@@ -77,34 +79,39 @@ class Qs::Event
     end
 
     should "be comparable" do
-      matching = @event_class.new(@channel, @name, @params, {
+      matching = @event_class.new(@channel, @name, {
+        :params       => @params,
         :publisher    => @publisher,
         :published_at => @published_at
       })
       assert_equal matching, subject
 
-      non_matching = @event_class.new(Factory.string, @name, @params, {
+      non_matching = @event_class.new(Factory.string, @name, {
+        :params       => @params,
         :publisher    => @publisher,
         :published_at => @published_at
       })
       assert_not_equal non_matching, subject
-      non_matching = @event_class.new(@channel, Factory.string, @params, {
+      non_matching = @event_class.new(@channel, Factory.string, {
+        :params       => @params,
         :publisher    => @publisher,
         :published_at => @published_at
       })
       assert_not_equal non_matching, subject
-      other_params = { Factory.string => Factory.string }
-      non_matching = @event_class.new(@channel, @name, other_params, {
+      non_matching = @event_class.new(@channel, @name, {
+        :params       => { Factory.string => Factory.string },
         :publisher    => @publisher,
         :published_at => @published_at
       })
       assert_not_equal non_matching, subject
-      non_matching = @event_class.new(@channel, @name, @params, {
+      non_matching = @event_class.new(@channel, @name, {
+        :params       => @params,
         :publisher    => Factory.string,
         :published_at => @published_at
       })
       assert_not_equal non_matching, subject
-      non_matching = @event_class.new(@channel, @name, @params, {
+      non_matching = @event_class.new(@channel, @name, {
+        :params       => @params,
         :publisher    => @publisher,
         :published_at => Factory.time
       })
@@ -112,14 +119,11 @@ class Qs::Event
     end
 
     should "raise an error when given invalid attributes" do
-      assert_raises(Qs::BadEventError){ @event_class.new(nil, @name, @params) }
-      assert_raises(Qs::BadEventError) do
-        @event_class.new(@channel, nil, @params)
+      assert_raises(InvalidError){ @event_class.new(nil, @name) }
+      assert_raises(InvalidError){ @event_class.new(@channel, nil) }
+      assert_raises(InvalidError) do
+        @event_class.new(@channel, @name, :params => Factory.string)
       end
-      assert_raises(Qs::BadEventError) do
-        @event_class.new(@channel, @name, Factory.string)
-      end
-      assert_raises(Qs::BadEventError){ @event_class.new(@channel, @name, nil) }
     end
 
   end

--- a/test/unit/job_tests.rb
+++ b/test/unit/job_tests.rb
@@ -32,7 +32,10 @@ class Qs::Job
       @current_time = Factory.time
       Assert.stub(Time, :now).with{ @current_time }
 
-      @job = @job_class.new(@name, @params, :created_at => @created_at)
+      @job = @job_class.new(@name, {
+        :params     => @params,
+        :created_at => @created_at
+      })
     end
     subject{ @job }
 
@@ -46,8 +49,9 @@ class Qs::Job
       assert_equal @created_at,   subject.created_at
     end
 
-    should "default its created at to the current time" do
-      job = @job_class.new(@name, @params)
+    should "default its params and created at to the current time" do
+      job = @job_class.new(@name)
+      assert_equal({}, job.params)
       assert_equal @current_time, job.created_at
     end
 
@@ -65,30 +69,32 @@ class Qs::Job
     end
 
     should "be comparable" do
-      matching = @job_class.new(@name, @params, {
+      matching = @job_class.new(@name, {
+        :params     => @params,
         :created_at => @created_at
       })
       assert_equal matching, subject
 
-      non_matching = @job_class.new(Factory.string, @params, {
+      non_matching = @job_class.new(Factory.string, {
+        :params     => @params,
         :created_at => @created_at
       })
       assert_not_equal non_matching, subject
-      other_params = { Factory.string => Factory.string }
-      non_matching = @job_class.new(@name, other_params, {
+      non_matching = @job_class.new(@name, {
+        :params     => { Factory.string => Factory.string },
         :created_at => @created_at
       })
       assert_not_equal non_matching, subject
-      non_matching = @job_class.new(@name, @params, {
+      non_matching = @job_class.new(@name, {
+        :params     => @params,
         :created_at => Factory.time
       })
       assert_not_equal non_matching, subject
     end
 
-    should "raise an error when given an invalid attributes" do
-      assert_raises(Qs::BadJobError){ @job_class.new(nil, @params) }
-      assert_raises(Qs::BadJobError){ @job_class.new(@name, nil) }
-      assert_raises(Qs::BadJobError){ @job_class.new(@name, Factory.string) }
+    should "raise an error when given invalid attributes" do
+      assert_raises(InvalidError){ @job_class.new(nil) }
+      assert_raises(InvalidError){ @job_class.new(@name, :params => Factory.string) }
     end
 
   end

--- a/test/unit/message_tests.rb
+++ b/test/unit/message_tests.rb
@@ -17,7 +17,7 @@ class Qs::Message
   class InitTests < UnitTests
     desc "when init"
     setup do
-      @message = @message_class.new(@payload_type, @params)
+      @message = @message_class.new(@payload_type, :params => @params)
     end
     subject{ @message }
 


### PR DESCRIPTION
This changes the `new` methods for jobs and events to expect their
params to be passed in an options hash instead of as an argument.
This is to avoid a double-hash at the end of the method signature.

By moving the params into the options, this makes them optional at
the `Job` and `Event` level. Previously, they were optional for
the `enqueue` and `publish` methods. This updates the `Job` and
the `Event` to default them to an empty hash and removes the
previous defaulting.

This also changes the errors thrown by `Job` and `Event` to be
nested under them and renames them to invalid instead of bad. This
is a better naming and lets them use the namespace of their
respective classes for identifying their role.

@kellyredding - Ready for review.