### PR TITLE
Add separate logging for jobs and events

### DIFF
--- a/bench/report.txt
+++ b/bench/report.txt
@@ -5,7 +5,7 @@ Adding jobs
 Running jobs
 ....................................................................................................
 
-Adding 10000 Jobs Time:   1.6360s
-Running 10000 Jobs Time: 11.1720s
+Adding 10000 Jobs Time:   1.5895s
+Running 10000 Jobs Time: 11.3055s
 
 Done running benchmark report

--- a/lib/qs/payload.rb
+++ b/lib/qs/payload.rb
@@ -6,18 +6,22 @@ module Qs
 
   module Payload
 
-    PAYLOAD_TYPES = Hash.new{ |h, t| raise(InvalidError.new(t)) }.tap do |h|
+    METHOD_NAMES = Hash.new{ |h, t| raise(InvalidError.new(t)) }.tap do |h|
       h[Job::PAYLOAD_TYPE]   = 'job'
       h[Event::PAYLOAD_TYPE] = 'event'
     end.freeze
 
+    def self.type_method_name(payload_type)
+      METHOD_NAMES[payload_type]
+    end
+
     def self.deserialize(encoded_payload)
       payload_hash = Qs.decode(encoded_payload)
-      self.send(PAYLOAD_TYPES[payload_hash['type']], payload_hash)
+      self.send(self.type_method_name(payload_hash['type']), payload_hash)
     end
 
     def self.serialize(message)
-      Qs.encode(self.send("#{PAYLOAD_TYPES[message.payload_type]}_hash", message))
+      Qs.encode(self.send("#{self.type_method_name(message.payload_type)}_hash", message))
     end
 
     def self.job(payload_hash)

--- a/test/unit/payload_tests.rb
+++ b/test/unit/payload_tests.rb
@@ -13,9 +13,16 @@ module Qs::Payload
     end
     subject{ Qs::Payload }
 
+    should have_imeths :type_method_name
     should have_imeths :deserialize, :serialize
     should have_imeths :job, :job_hash
     should have_imeths :event, :event_hash
+
+    should "convert payload types to method names using `type_method_name`" do
+      assert_equal 'job',   subject.type_method_name(Qs::Job::PAYLOAD_TYPE)
+      assert_equal 'event', subject.type_method_name(Qs::Event::PAYLOAD_TYPE)
+      assert_raises(InvalidError){ subject.type_method_name(Factory.string) }
+    end
 
     should "serialize and deserialize messages" do
       message = Factory.message


### PR DESCRIPTION
This updates the `PayloadHandler` to do custom logging for
different types of messages. Events and jobs will now do different
logging to help differentiate what the message being processed is.
This is to avoid confusion and be explicit about what Qs background
process is doing.

This also changes the `Payload` to have a `type_method_name` method
that converts payload types to method names. This is to validate
that payload types, which can come from the redis DB, do not
execute arbitrary code via `send`. This was previously being done
only for the `Payload` module but the same process is needed for
the `PayloadHandler`. This formalizes the conversion so that the
`PayloadHandler` can make use of it.

@kellyredding - Ready for review.