### PR TITLE
Add `DispatchJobHandler`

### DIFF
--- a/lib/qs.rb
+++ b/lib/qs.rb
@@ -73,6 +73,10 @@ module Qs
     self.client.clear_subscriptions(queue)
   end
 
+  def self.event_subscribers(event)
+    self.client.event_subscribers(event)
+  end
+
   def self.client
     @client
   end

--- a/lib/qs/client.rb
+++ b/lib/qs/client.rb
@@ -90,6 +90,10 @@ module Qs
         end
       end
 
+      def event_subscribers(event)
+        self.redis.with{ |c| c.smembers(event.subscribers_redis_key) }
+      end
+
       private
 
       def publish!(channel, name, options = nil)

--- a/lib/qs/dispatch_job.rb
+++ b/lib/qs/dispatch_job.rb
@@ -6,6 +6,14 @@ module Qs
 
   class DispatchJob < Qs::Job
 
+    def self.event(job)
+      Qs::Event.new(job.params['event_channel'], job.params['event_name'], {
+        :params       => job.params['event_params'],
+        :publisher    => job.params['event_publisher'],
+        :published_at => job.created_at
+      })
+    end
+
     def initialize(event_channel, event_name, options = nil)
       options ||= {}
       event_params    = options.delete(:event_params)    || {}
@@ -20,11 +28,7 @@ module Qs
     end
 
     def event
-      @event ||= Qs::Event.new(params['event_channel'], params['event_name'], {
-        :params       => params['event_params'],
-        :publisher    => params['event_publisher'],
-        :published_at => self.created_at
-      })
+      @event ||= self.class.event(self)
     end
 
   end

--- a/lib/qs/dispatch_job_handler.rb
+++ b/lib/qs/dispatch_job_handler.rb
@@ -1,0 +1,79 @@
+require 'qs'
+require 'qs/dispatch_job'
+require 'qs/job_handler'
+
+module Qs
+
+  module DispatchJobHandler
+
+    def self.included(klass)
+      klass.class_eval do
+        include Qs::JobHandler
+        include InstanceMethods
+      end
+    end
+
+    module InstanceMethods
+
+      attr_reader :event, :subscribed_queue_names
+
+      def init!
+        @event = Qs::DispatchJob.event(job)
+        @subscribed_queue_names = Qs.event_subscribers(@event)
+        @qs_failed_dispatches = []
+      end
+
+      def run!
+        logger.info "Dispatching #{self.event.route_name}"
+        logger.info "  params:       #{self.event.params.inspect}"
+        logger.info "  publisher:    #{self.event.publisher}"
+        logger.info "  published at: #{self.event.published_at}"
+        logger.info "Found #{self.subscribed_queue_names.size} subscribed queue(s)"
+        self.subscribed_queue_names.each do |queue_name|
+          qs_dispatch(queue_name, self.event)
+        end
+        qs_handle_errors(self.event, @qs_failed_dispatches)
+      end
+
+      private
+
+      def qs_dispatch(queue_name, event)
+        Qs.push(queue_name, Qs::Payload.event_hash(event))
+        logger.info "  => #{queue_name}"
+      rescue StandardError => exception
+        logger.info "  => #{queue_name} (failed)"
+        @qs_failed_dispatches << FailedDispatch.new(queue_name, exception)
+      end
+
+      def qs_handle_errors(event, failed_dispatches)
+        return if failed_dispatches.empty?
+        logger.info "Failed to dispatch the event to " \
+                    "#{failed_dispatches.size} subscribed queues"
+        descriptions = failed_dispatches.map do |fail|
+          exception_desc = "#{fail.exception.class}: #{fail.exception.message}"
+          logger.info "#{fail.queue_name}"
+          logger.info "  #{exception_desc}"
+          logger.info "  #{fail.exception.backtrace.first}"
+          "#{fail.queue_name} - #{exception_desc}"
+        end
+        message = "#{event.route_name} event wasn't dispatched to:\n" \
+                  "  #{descriptions.join("\n  ")}"
+        raise DispatchError.new(message, failed_dispatches)
+      end
+
+    end
+
+    FailedDispatch = Struct.new(:queue_name, :exception)
+
+    class DispatchError < RuntimeError
+      attr_reader :failed_dispatches
+
+      def initialize(message, failed_dispatches)
+        super message
+        @failed_dispatches = failed_dispatches
+      end
+    end
+
+  end
+
+end

--- a/lib/qs/event.rb
+++ b/lib/qs/event.rb
@@ -23,6 +23,10 @@ module Qs
       @route_name ||= Event::RouteName.new(self.channel, self.name)
     end
 
+    def subscribers_redis_key
+      @subscribers_redis_key ||= SubscribersRedisKey.new(self.route_name)
+    end
+
     def inspect
       reference = '0x0%x' % (self.object_id << 1)
       "#<#{self.class}:#{reference} " \

--- a/test/unit/client_tests.rb
+++ b/test/unit/client_tests.rb
@@ -53,6 +53,7 @@ module Qs::Client
     should have_imeths :append, :prepend
     should have_imeths :clear
     should have_imeths :sync_subscriptions, :clear_subscriptions
+    should have_imeths :event_subscribers
 
     should "know its redis config" do
       assert_equal @redis_config, subject.redis_config
@@ -168,6 +169,21 @@ module Qs::Client
 
       call = @connection_spy.redis_calls.last
       assert_equal :ping, call.command
+    end
+
+    should "return the events subscriber set using `event_subscribers`" do
+      smembers_key = nil
+      smembers = Factory.integer(3).times.map{ Factory.string }
+      Assert.stub(@connection_spy.redis_spy, :smembers) do |key|
+        smembers_key = key
+        smembers
+      end
+
+      event = Factory.event
+      result = subject.event_subscribers(event)
+
+      assert_equal event.subscribers_redis_key, smembers_key
+      assert_equal smembers, result
     end
 
   end

--- a/test/unit/dispatch_job_handler_tests.rb
+++ b/test/unit/dispatch_job_handler_tests.rb
@@ -1,0 +1,163 @@
+require 'assert'
+require 'qs/dispatch_job_handler'
+
+require 'qs/job_handler_test_helpers'
+
+module Qs::DispatchJobHandler
+
+  class UnitTests < Assert::Context
+    include Qs::JobHandler::TestHelpers
+
+    desc "Qs::DispatchJobHandler"
+    setup do
+      Qs.init
+      @handler_class = Class.new do
+        include Qs::DispatchJobHandler
+      end
+    end
+    teardown do
+      Qs.reset!
+    end
+    subject{ @handler_class }
+
+    should "be a job handler" do
+      assert_includes Qs::JobHandler, subject
+    end
+
+  end
+
+  class InitSetupTests < UnitTests
+    desc "when init"
+    setup do
+      @job = Factory.dispatch_job(:publisher => Factory.string)
+      @queue_names = Factory.integer(3).times.map{ Factory.string }
+      Assert.stub(Qs, :event_subscribers){ @queue_names }
+
+      @push_calls = []
+      Assert.stub(Qs, :push){ |*args| @push_calls << PushCall.new(*args) }
+
+      @logger_spy  = LoggerSpy.new
+      @runner_args = {
+        :job    => @job,
+        :params => @job.params,
+        :logger => @logger_spy
+      }
+    end
+    subject{ @handler }
+
+  end
+
+  class InitTests < InitSetupTests
+    setup do
+      @runner  = test_runner(@handler_class, @runner_args)
+      @handler = @runner.handler
+    end
+
+    should "know its event and subscribed queue names" do
+      assert_equal @job.event,   subject.event
+      assert_equal @queue_names, subject.subscribed_queue_names
+    end
+
+  end
+
+  class RunTests < InitTests
+    desc "and run"
+    setup do
+      @runner.run
+    end
+
+    should "push the events payload to all of the subscribed queue names" do
+      assert_equal @queue_names, @push_calls.map(&:queue_name)
+      exp = Qs::Payload.event_hash(subject.event)
+      assert_equal [exp], @push_calls.map(&:payload).uniq
+    end
+
+    should "log the queues it dispatches to" do
+      exp = [
+        "Dispatching #{subject.event.route_name}",
+        "  params:       #{subject.event.params.inspect}",
+        "  publisher:    #{subject.event.publisher}",
+        "  published at: #{subject.event.published_at}",
+        "Found #{subject.subscribed_queue_names.size} subscribed queue(s)",
+        @queue_names.map{ |queue_name| "  => #{queue_name}" }
+      ].flatten.join("\n")
+      assert_equal exp, @logger_spy.messages.join("\n")
+    end
+
+  end
+
+  class RunWithDispatchesThatErrorTests < InitSetupTests
+    desc "and run with dispatches that error"
+    setup do
+      @fail_queue_names = Factory.integer(3).times.map{ Factory.string }
+      @dispatch_error = RuntimeError.new(Factory.text)
+      payload_hash = Qs::Payload.event_hash(@job.event)
+      @fail_queue_names.each do |queue_name|
+        Assert.stub(Qs, :push).with(queue_name, payload_hash) do
+          raise @dispatch_error
+        end
+      end
+
+      @success_queue_names = @queue_names.dup
+      # add the fail queue names to the front to test that they don't cause
+      # the other queues not to be dispatched to
+      @queue_names = @fail_queue_names + @success_queue_names
+
+      @runner  = test_runner(@handler_class, @runner_args)
+      @handler = @runner.handler
+
+      @exception = nil
+      begin; @runner.run; rescue => @exception; end
+    end
+
+    should "raise a dispatch error after trying to dispatch to every queue" do
+      assert_equal @success_queue_names, @push_calls.map(&:queue_name)
+
+      assert_instance_of DispatchError, @exception
+      descriptions = @fail_queue_names.map do |queue_name|
+        "#{queue_name} - #{@dispatch_error.class}: #{@dispatch_error.message}"
+      end
+      exp = "#{subject.event.route_name} event wasn't dispatched to:\n" \
+            "  #{descriptions.join("\n  ")}"
+      assert_equal exp, @exception.message
+      exp = @fail_queue_names.map do |queue_name|
+        FailedDispatch.new(queue_name, @dispatch_error)
+      end
+      assert_equal exp, @exception.failed_dispatches
+    end
+
+    should "log the queues it dispatches to and the errors it encounters" do
+      exp = [
+        "Dispatching #{subject.event.route_name}",
+        "  params:       #{subject.event.params.inspect}",
+        "  publisher:    #{subject.event.publisher}",
+        "  published at: #{subject.event.published_at}",
+        "Found #{subject.subscribed_queue_names.size} subscribed queue(s)",
+        @fail_queue_names.map{ |queue_name| "  => #{queue_name} (failed)" },
+        @success_queue_names.map{ |queue_name| "  => #{queue_name}" },
+        "Failed to dispatch the event to #{@fail_queue_names.size} subscribed queues",
+        @fail_queue_names.map do |queue_name|
+          [ queue_name,
+            "  #{@dispatch_error.class}: #{@dispatch_error.message}",
+            "  #{@dispatch_error.backtrace.first}"
+          ]
+        end
+      ].flatten.join("\n")
+      assert_equal exp, @logger_spy.messages.join("\n")
+    end
+
+  end
+
+  PushCall = Struct.new(:queue_name, :payload)
+
+  class LoggerSpy
+    attr_reader :messages
+
+    def initialize
+      @messages = []
+    end
+
+    def info(message); @messages << message; end
+  end
+
+end

--- a/test/unit/event_tests.rb
+++ b/test/unit/event_tests.rb
@@ -43,7 +43,7 @@ class Qs::Event
     subject{ @event }
 
     should have_readers :channel, :name, :publisher, :published_at
-    should have_imeths :route_name
+    should have_imeths :route_name, :subscribers_redis_key
 
     should "know its attributes" do
       assert_equal PAYLOAD_TYPE,  subject.payload_type
@@ -65,6 +65,11 @@ class Qs::Event
       result = subject.route_name
       assert_equal exp, result
       assert_same result, subject.route_name
+    end
+
+    should "know its subscribers redis key" do
+      exp = SubscribersRedisKey.new(subject.route_name)
+      assert_equal exp, subject.subscribers_redis_key
     end
 
     should "have a custom inspect" do


### PR DESCRIPTION
This adds a `DispatchJobHandler` mixin which can be used to
define a job handler that handles dispatching events. This handler
is setup to receive `DispatchJob`s and add events to subscribed
queues. This is provided as a mixin so it can be mixed into a
handler where callbacks can be added for custom behavior. This is
part of the events system.

The handler uses `Qs` to read its subscribers from redis and for
each of them it pushes its events payload onto their queue. The
handler is fault tolerant so if an error occurs while pushing an
event onto a queue it will continue trying to push to all queues
before erroring.

@kellyredding - Ready for review.