### PR TITLE
Update dispatcher queue

### DIFF
--- a/lib/qs/dispatcher_queue.rb
+++ b/lib/qs/dispatcher_queue.rb
@@ -1,0 +1,19 @@
+require 'qs/queue'
+require 'qs/dispatch_job_handler'
+
+module Qs
+
+  module DispatcherQueue
+
+    def self.new(options)
+      options[:queue_class].new do
+        name options[:queue_name]
+        job options[:job_name], options[:job_handler_class_name]
+      end
+    end
+
+    RunDispatchJob = Class.new{ include Qs::DispatchJobHandler }
+
+  end
+
+end

--- a/test/unit/dispatcher_queue_tests.rb
+++ b/test/unit/dispatcher_queue_tests.rb
@@ -1,0 +1,42 @@
+require 'assert'
+require 'qs/dispatcher_queue'
+
+module Qs::DispatcherQueue
+
+  class UnitTests < Assert::Context
+    desc "Qs::DispatcherQueue"
+    subject{ Qs::DispatcherQueue }
+
+    should have_imeths :new
+
+    should "build a dispatcher queue" do
+      options = {
+        :queue_class            => Class.new(Qs::Queue),
+        :queue_name             => Factory.string,
+        :job_name               => Factory.string,
+        :job_handler_class_name => Factory.string
+      }
+      dispatcher_queue = subject.new(options)
+      assert_instance_of options[:queue_class], dispatcher_queue
+      assert_equal options[:queue_name], dispatcher_queue.name
+
+      route = dispatcher_queue.routes.last
+      assert_instance_of Qs::Route, route
+      exp = Qs::Message::RouteId.new(Qs::Job::PAYLOAD_TYPE, options[:job_name])
+      assert_equal exp, route.id
+      assert_equal options[:job_handler_class_name], route.handler_class_name
+    end
+
+  end
+
+  class RunDispatchJobTests < UnitTests
+    desc "RunDispatchJob"
+    subject{ RunDispatchJob }
+
+    should "be a dispatch job handler" do
+      assert_includes Qs::DispatchJobHandler, subject
+    end
+
+  end
+
+end


### PR DESCRIPTION
This updates Qs dispatch logic to allow configuring a dispatcher
queue class and job handler class name in addition to a queue name
and job name. This enables Qs to build a working dispatcher queue
that is configured to handle dispatch jobs. It also enables
enabling custom `Queue` behavior by specifying your own queue class
for the dispatcher queue. This is part of the events system.

@kellyredding - Ready for review.