### PR TITLE
Add subscription system tests, fix sync to remove unneeded subscribers

### DIFF
--- a/lib/qs.rb
+++ b/lib/qs.rb
@@ -126,7 +126,7 @@ module Qs
     end
 
     namespace :redis do
-      option :ip,   :default => 'localhost'
+      option :ip,   :default => '127.0.0.1'
       option :port, :default => 6379
       option :db,   :default => 0
 

--- a/test/system/queue_tests.rb
+++ b/test/system/queue_tests.rb
@@ -1,0 +1,87 @@
+require 'assert'
+require 'qs'
+
+require 'test/support/app_daemon'
+
+class Qs::Queue
+
+  class SystemTests < Assert::Context
+    desc "Qs::Queue"
+    setup do
+      Qs.reset!
+      @qs_test_mode = ENV['QS_TEST_MODE']
+      ENV['QS_TEST_MODE'] = nil
+      Qs.init
+
+      @event = Qs::Event.new('qs-app', 'basic')
+      @other_queue = Qs::Queue.new{ name(Factory.string) }
+      @other_queue.event(@event.channel, @event.name, Factory.string)
+    end
+    teardown do
+      Qs.redis.with do |c|
+        keys = c.keys('*qs-app*')
+        c.pipelined{ keys.each{ |k| c.del(k) } }
+      end
+      Qs.reset!
+      ENV['QS_TEST_MODE'] = @qs_test_mode
+    end
+
+  end
+
+  class SyncSubscriptionsTests < SystemTests
+    desc "sync_subscriptions"
+    setup do
+      AppQueue.sync_subscriptions
+    end
+
+    should "store subscriptions for the queue in redis" do
+      AppQueue.event_route_names.each do |route_name|
+        redis_key = Qs::Event::SubscribersRedisKey.new(route_name)
+        smembers = Qs.redis.with{ |c| c.smembers(redis_key) }
+        assert_includes AppQueue.name, smembers
+      end
+    end
+
+    should "allow adding a new queues subscriptions but preserve the existing" do
+      @other_queue.sync_subscriptions
+
+      smembers = Qs.redis.with{ |c| c.smembers(@event.subscribers_redis_key) }
+      assert_equal 2, smembers.size
+      assert_includes AppQueue.name,     smembers
+      assert_includes @other_queue.name, smembers
+    end
+
+    should "remove subscriptions if a queue no longer subscribes to the event" do
+      route_names = AppQueue.event_route_names.reject{ |n| n == @event.route_name }
+      Assert.stub(AppQueue, :event_route_names){ route_names }
+      AppQueue.sync_subscriptions
+
+      redis_key = Qs::Event.new('qs-app', 'basic').subscribers_redis_key
+      smembers = Qs.redis.with{ |c| c.smembers(redis_key) }
+      assert_not_includes AppQueue.name, smembers
+    end
+
+  end
+
+  class ClearSubscriptionsTests < SystemTests
+    desc "clear_subscriptions"
+    setup do
+      AppQueue.sync_subscriptions
+      @other_queue.sync_subscriptions
+      AppQueue.clear_subscriptions
+    end
+
+    should "remove the queue from all of its events subscribers" do
+      AppQueue.event_route_names.each do |route_name|
+        redis_key = Qs::Event::SubscribersRedisKey.new(route_name)
+        smembers = Qs.redis.with{ |c| c.smembers(redis_key) }
+        assert_not_includes AppQueue.name, smembers
+      end
+
+      smembers = Qs.redis.with{ |c| c.smembers(@event.subscribers_redis_key) }
+      assert_equal [@other_queue.name], smembers
+    end
+
+  end
+
+end

--- a/test/unit/qs_tests.rb
+++ b/test/unit/qs_tests.rb
@@ -256,7 +256,7 @@ module Qs
     end
 
     should "know its default redis options" do
-      assert_equal 'localhost', subject.redis.ip
+      assert_equal '127.0.0.1', subject.redis.ip
       assert_equal 6379,        subject.redis.port
       assert_equal 0,           subject.redis.db
       assert_equal 'qs',        subject.redis.redis_ns


### PR DESCRIPTION
This adds subscription system tests and fixes a bug in the sync
subscriptions to properly unsubscribe the queue from events if it
no longer listens for them. This is part of the events system and
making sure everything works as expected.

The sync previously just added its queue to its current events
subscribers sets. The issue is if the queue once was listening for
an event but no longer is, it needs to remove itself as a
subscriber of that event. This does that by removing itself from
all events subscribers and then adding itself to the current events
its listening for. This is done in a transaction so there it won't
lose any events while its subscriptions are being synced.

@kellyredding - Ready for review. Found a small bug with the syncing while doing this and fixed it. This is the last of my PRs for Qs for now.