### PR TITLE
move process label configuration into the daemon

### DIFF
--- a/lib/qs/daemon.rb
+++ b/lib/qs/daemon.rb
@@ -63,6 +63,10 @@ module Qs
         @daemon_data.name
       end
 
+      def process_label
+        @daemon_data.process_label
+      end
+
       def pid_file
         @daemon_data.pid_file
       end
@@ -286,11 +290,13 @@ module Qs
 
       option :shutdown_timeout
 
+      attr_accessor :process_label
       attr_accessor :init_procs, :error_procs
       attr_accessor :queues
 
       def initialize(values = nil)
         super(values)
+        @process_label = (v = ENV['QS_PROCESS_LABEL']) && !v.to_s.empty? ? v : self.name
         @init_procs, @error_procs = [], []
         @queues = []
         @valid = nil
@@ -302,9 +308,10 @@ module Qs
 
       def to_hash
         super.merge({
+          :process_label    => self.process_label,
           :error_procs      => self.error_procs,
-          :queue_redis_keys => self.queues.map(&:redis_key),
-          :routes           => self.routes
+          :routes           => self.routes,
+          :queue_redis_keys => self.queues.map(&:redis_key)
         })
       end
 

--- a/lib/qs/daemon_data.rb
+++ b/lib/qs/daemon_data.rb
@@ -7,7 +7,7 @@ module Qs
     # options one time here and memoize their values. This way, we don't pay the
     # NsOptions overhead when reading them while handling a message.
 
-    attr_reader :name
+    attr_reader :name, :process_label
     attr_reader :pid_file
     attr_reader :min_workers, :max_workers
     attr_reader :logger, :verbose_logging
@@ -18,6 +18,7 @@ module Qs
     def initialize(args = nil)
       args ||= {}
       @name             = args[:name]
+      @process_label    = args[:process_label]
       @pid_file         = args[:pid_file]
       @min_workers      = args[:min_workers]
       @max_workers      = args[:max_workers]

--- a/lib/qs/process.rb
+++ b/lib/qs/process.rb
@@ -17,8 +17,7 @@ module Qs
     def initialize(daemon, options = nil)
       options ||= {}
       @daemon = daemon
-      process_label = ignore_if_blank(ENV['QS_PROCESS_LABEL']) || @daemon.name
-      @name   = "qs: #{process_label}"
+      @name   = "qs: #{@daemon.process_label}"
       @logger = @daemon.logger
 
       @pid_file    = PIDFile.new(@daemon.pid_file)

--- a/qs.gemspec
+++ b/qs.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency("ns-options",      ["~> 1.1"])
   gem.add_dependency("SystemTimer",     ["~> 1.2"])
 
-  gem.add_development_dependency("assert", ["~> 2.14"])
+  gem.add_development_dependency("assert", ["~> 2.15"])
   gem.add_development_dependency("scmd",   ["~> 2.3"])
 end

--- a/test/unit/daemon_data_tests.rb
+++ b/test/unit/daemon_data_tests.rb
@@ -9,21 +9,24 @@ class Qs::DaemonData
   class UnitTests < Assert::Context
     desc "Qs::DaemonData"
     setup do
-      @name = Factory.string
-      @pid_file = Factory.file_path
-      @min_workers = Factory.integer
-      @max_workers = Factory.integer
-      @logger = Factory.string
-      @verbose_logging = Factory.boolean
+      @name             = Factory.string
+      @process_label    = Factory.string
+      @pid_file         = Factory.file_path
+      @min_workers      = Factory.integer
+      @max_workers      = Factory.integer
+      @logger           = Factory.string
+      @verbose_logging  = Factory.boolean
       @shutdown_timeout = Factory.integer
-      @error_procs = [ proc{ Factory.string } ]
+      @error_procs      = [ proc{ Factory.string } ]
       @queue_redis_keys = (0..Factory.integer(3)).map{ Factory.string }
+
       @routes = (0..Factory.integer(3)).map do
         Qs::Route.new(Factory.string, TestHandler.to_s).tap(&:validate!)
       end
 
       @daemon_data = Qs::DaemonData.new({
         :name             => @name,
+        :process_label    => @process_label,
         :pid_file         => @pid_file,
         :min_workers      => @min_workers,
         :max_workers      => @max_workers,
@@ -37,7 +40,7 @@ class Qs::DaemonData
     end
     subject{ @daemon_data }
 
-    should have_readers :name
+    should have_readers :name, :process_label
     should have_readers :pid_file
     should have_readers :min_workers, :max_workers
     should have_readers :logger, :verbose_logging
@@ -48,6 +51,7 @@ class Qs::DaemonData
 
     should "know its attributes" do
       assert_equal @name,             subject.name
+      assert_equal @process_label,    subject.process_label
       assert_equal @pid_file,         subject.pid_file
       assert_equal @min_workers,      subject.min_workers
       assert_equal @max_workers,      subject.max_workers

--- a/test/unit/process_tests.rb
+++ b/test/unit/process_tests.rb
@@ -22,9 +22,7 @@ class Qs::Process
   class InitTests < UnitTests
     desc "when init"
     setup do
-      @current_env_process_label  = ENV['QS_PROCESS_LABEL']
       @current_env_skip_daemonize = ENV['QS_SKIP_DAEMONIZE']
-      ENV.delete('QS_PROCESS_LABEL')
       ENV.delete('QS_SKIP_DAEMONIZE')
 
       @daemon_spy = DaemonSpy.new
@@ -41,7 +39,6 @@ class Qs::Process
     end
     teardown do
       ENV['QS_SKIP_DAEMONIZE'] = @current_env_skip_daemonize
-      ENV['QS_PROCESS_LABEL']  = @current_env_process_label
     end
     subject{ @process }
 
@@ -54,23 +51,11 @@ class Qs::Process
     end
 
     should "know its name, pid file, signal io and restart cmd" do
-      assert_equal "qs: #{@daemon_spy.name}", subject.name
+      assert_equal "qs: #{@daemon_spy.process_label}", subject.name
       assert_equal @pid_file_spy, subject.pid_file
       assert_instance_of Qs::IOPipe, subject.signal_io
       assert_equal @restart_cmd_spy, subject.restart_cmd
     end
-
-    should "set its name using env vars" do
-      ENV['QS_PROCESS_LABEL'] = Factory.string
-      process = @process_class.new(@daemon_spy)
-      assert_equal "qs: #{ENV['QS_PROCESS_LABEL']}", process.name
-    end
-
-    should "ignore blank env values for its name" do
-      ENV['QS_PROCESS_LABEL'] = ''
-      process = @process_class.new(@daemon_spy)
-      assert_equal "qs: #{@daemon_spy.name}", process.name
-     end
 
     should "not daemonize by default" do
       process = @process_class.new(@daemon_spy)
@@ -415,11 +400,15 @@ class Qs::Process
 
     queue Qs::Queue.new{ name Factory.string }
 
+    attr_accessor :process_label
     attr_accessor :start_called, :stop_called, :halt_called
     attr_reader :start_args, :stop_args, :halt_args
 
     def initialize(*args)
       super
+
+      @process_label = Factory.string
+
       @start_args   = nil
       @start_called = false
       @stop_args    = nil


### PR DESCRIPTION
This is more consistent with the process *id* configuration already
being in the daemon.  This also has the benefit of keeping all
non-internal configuration handling being done via the daemon.  The
daemon data object that is passed around now is aware of the process
label.

This option is a little different from the others as it isn't
intended to be driven via a DSL option and also that it can instead
be driven by an ENV var.

The process label attr behaves just as it did before: it still
defaults to the daemon `name`, it can be specified using the same
`QS_PROCESS_LABEL` env var, and it is still applied to the process
name as before.

The goal here is to make the process label value available to the
error handler in a standard way (via the daemon data) just like all
other user-driven configuration values.

@jcredding how does this look?  Is it what you would expect?  ready for review.