### PR TITLE
expose dat-worker-pool worker callback configuration

### DIFF
--- a/lib/qs/daemon_data.rb
+++ b/lib/qs/daemon_data.rb
@@ -10,6 +10,8 @@ module Qs
     attr_reader :name, :process_label
     attr_reader :pid_file
     attr_reader :min_workers, :max_workers
+    attr_reader :worker_start_procs, :worker_shutdown_procs
+    attr_reader :worker_sleep_procs, :worker_wakeup_procs
     attr_reader :logger, :verbose_logging
     attr_reader :shutdown_timeout
     attr_reader :error_procs
@@ -17,17 +19,21 @@ module Qs
 
     def initialize(args = nil)
       args ||= {}
-      @name             = args[:name]
-      @process_label    = args[:process_label]
-      @pid_file         = args[:pid_file]
-      @min_workers      = args[:min_workers]
-      @max_workers      = args[:max_workers]
-      @logger           = args[:logger]
-      @verbose_logging  = !!args[:verbose_logging]
-      @shutdown_timeout = args[:shutdown_timeout]
-      @error_procs      = args[:error_procs] || []
-      @queue_redis_keys = args[:queue_redis_keys] || []
-      @routes           = build_routes(args[:routes] || [])
+      @name                  = args[:name]
+      @process_label         = args[:process_label]
+      @pid_file              = args[:pid_file]
+      @min_workers           = args[:min_workers]
+      @max_workers           = args[:max_workers]
+      @worker_start_procs    = args[:worker_start_procs]
+      @worker_shutdown_procs = args[:worker_shutdown_procs]
+      @worker_sleep_procs    = args[:worker_sleep_procs]
+      @worker_wakeup_procs   = args[:worker_wakeup_procs]
+      @logger                = args[:logger]
+      @verbose_logging       = !!args[:verbose_logging]
+      @shutdown_timeout      = args[:shutdown_timeout]
+      @error_procs           = args[:error_procs] || []
+      @queue_redis_keys      = args[:queue_redis_keys] || []
+      @routes                = build_routes(args[:routes] || [])
     end
 
     def route_for(route_id)

--- a/test/unit/daemon_data_tests.rb
+++ b/test/unit/daemon_data_tests.rb
@@ -14,28 +14,36 @@ class Qs::DaemonData
       @pid_file         = Factory.file_path
       @min_workers      = Factory.integer
       @max_workers      = Factory.integer
+      @start_procs      = Factory.integer(3).times.map{ proc{} }
+      @shutdown_procs   = Factory.integer(3).times.map{ proc{} }
+      @sleep_procs      = Factory.integer(3).times.map{ proc{} }
+      @wakeup_procs     = Factory.integer(3).times.map{ proc{} }
       @logger           = Factory.string
       @verbose_logging  = Factory.boolean
       @shutdown_timeout = Factory.integer
       @error_procs      = [ proc{ Factory.string } ]
-      @queue_redis_keys = (0..Factory.integer(3)).map{ Factory.string }
+      @queue_redis_keys = Factory.integer(3).times.map{ Factory.string }
 
       @routes = (0..Factory.integer(3)).map do
         Qs::Route.new(Factory.string, TestHandler.to_s).tap(&:validate!)
       end
 
       @daemon_data = Qs::DaemonData.new({
-        :name             => @name,
-        :process_label    => @process_label,
-        :pid_file         => @pid_file,
-        :min_workers      => @min_workers,
-        :max_workers      => @max_workers,
-        :logger           => @logger,
-        :verbose_logging  => @verbose_logging,
-        :shutdown_timeout => @shutdown_timeout,
-        :error_procs      => @error_procs,
-        :queue_redis_keys => @queue_redis_keys,
-        :routes           => @routes
+        :name                  => @name,
+        :process_label         => @process_label,
+        :pid_file              => @pid_file,
+        :min_workers           => @min_workers,
+        :max_workers           => @max_workers,
+        :worker_start_procs    => @start_procs,
+        :worker_shutdown_procs => @shutdown_procs,
+        :worker_sleep_procs    => @sleep_procs,
+        :worker_wakeup_procs   => @wakeup_procs,
+        :logger                => @logger,
+        :verbose_logging       => @verbose_logging,
+        :shutdown_timeout      => @shutdown_timeout,
+        :error_procs           => @error_procs,
+        :queue_redis_keys      => @queue_redis_keys,
+        :routes                => @routes
       })
     end
     subject{ @daemon_data }
@@ -43,6 +51,8 @@ class Qs::DaemonData
     should have_readers :name, :process_label
     should have_readers :pid_file
     should have_readers :min_workers, :max_workers
+    should have_readers :worker_start_procs, :worker_shutdown_procs
+    should have_readers :worker_sleep_procs, :worker_wakeup_procs
     should have_readers :logger, :verbose_logging
     should have_readers :shutdown_timeout
     should have_readers :error_procs
@@ -55,6 +65,10 @@ class Qs::DaemonData
       assert_equal @pid_file,         subject.pid_file
       assert_equal @min_workers,      subject.min_workers
       assert_equal @max_workers,      subject.max_workers
+      assert_equal @start_procs,      subject.worker_start_procs
+      assert_equal @shutdown_procs,   subject.worker_shutdown_procs
+      assert_equal @sleep_procs,      subject.worker_sleep_procs
+      assert_equal @wakeup_procs,     subject.worker_wakeup_procs
       assert_equal @logger,           subject.logger
       assert_equal @verbose_logging,  subject.verbose_logging
       assert_equal @shutdown_timeout, subject.shutdown_timeout


### PR DESCRIPTION
This adds configuraion/dsl methods for ad-hoc adding dat-worker-pool
worker callback for start, shutdown, sleep and wakeup.  This allows
3rd party users of Qs to add their own callbacks.

Practically speaking this will allow getting the thread id of any new
workers and setting that in our log configs so that each worker logs
with its own thread id.

@jcredding ready for review.  I still need to verify this will work in our apps, FYI.