### PR TITLE
Switch worker available from IO pipe to mutex/condition variable

### DIFF
--- a/test/unit/daemon_tests.rb
+++ b/test/unit/daemon_tests.rb
@@ -757,6 +757,24 @@ module Qs::Daemon
 
   end
 
+  class WorkerAvailableTests < UnitTests
+    desc "WorkerAvailable"
+    setup do
+      @worker_available = WorkerAvailable.new
+    end
+    subject{ @worker_available }
+
+    should have_imeths :wait, :signal
+
+    should "allow waiting and signalling" do
+      thread = Thread.new{ subject.wait }
+      assert_equal 'sleep', thread.status
+      subject.signal
+      assert_equal false, thread.status # dead, done running
+    end
+
+  end
+
   TestHandler = Class.new
 
   class PayloadHandlerSpy


### PR DESCRIPTION
This switches the worker available logic in the daemon from using
an IO pipe to a mutex and condition variable. This fixes an issue
with the IO pipe erroring after a high volume of jobs in a short
period of time. The IO pipe started raising an EAGAIN resource
temporarily unavailable after it received and processed a large
number of jobs in short period of time.

This is a simpler implementation and it better fits the needs for
the worker available logic. Previously, it would write a value to
the IO pipe, but this value was never used. With the mutex and
condition variable it doesn't have to worry about a value.

@kellyredding - Ready for review.