### PR TITLE
Update to use the new scmd, setup for working with ruby 1.9+

### DIFF
--- a/qs.gemspec
+++ b/qs.gemspec
@@ -24,5 +24,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency("SystemTimer",     ["~> 1.2"])
 
   gem.add_development_dependency("assert", ["~> 2.15"])
-  gem.add_development_dependency("scmd",   ["~> 2.3"])
+  gem.add_development_dependency("scmd",   ["~> 3.0"])
+
 end


### PR DESCRIPTION
This updates to use the new scmd and also does some setup work for
working with ruby 1.9+.

Scmd changed how env vars are passed to commands and also allows
passing spawn options. The bench report script was updated to pass
its env vars correctly and now also passes file descriptor
redirection options for its pipe writer. Passing redirection
options is needed for ruby 1.9+ to ensure the child process can
open the pipe writer IO.

This also updates the bundle exec command to use the keep file
descriptors flag which is also needed for ruby 1.9+ for the same
reason. Otherwise the child process can't open the pipe writer
IO.

@kellyredding - Ready for review.