### PR TITLE
Move using the process label env var into the daemon data

### DIFF
--- a/lib/qs/daemon.rb
+++ b/lib/qs/daemon.rb
@@ -311,7 +311,6 @@ module Qs
 
       option :shutdown_timeout
 
-      attr_accessor :process_label
       attr_accessor :init_procs, :error_procs
       attr_accessor :queues
       attr_reader :worker_start_procs, :worker_shutdown_procs
@@ -319,7 +318,6 @@ module Qs
 
       def initialize(values = nil)
         super(values)
-        @process_label = !(v = ENV['QS_PROCESS_LABEL'].to_s).empty? ? v : self.name
         @init_procs, @error_procs = [], []
         @worker_start_procs, @worker_shutdown_procs = [], []
         @worker_sleep_procs, @worker_wakeup_procs   = [], []
@@ -333,7 +331,6 @@ module Qs
 
       def to_hash
         super.merge({
-          :process_label         => self.process_label,
           :error_procs           => self.error_procs,
           :worker_start_procs    => self.worker_start_procs,
           :worker_shutdown_procs => self.worker_shutdown_procs,

--- a/lib/qs/daemon_data.rb
+++ b/lib/qs/daemon_data.rb
@@ -20,7 +20,7 @@ module Qs
     def initialize(args = nil)
       args ||= {}
       @name                  = args[:name]
-      @process_label         = args[:process_label]
+      @process_label         = !(v = ENV['QS_PROCESS_LABEL'].to_s).empty? ? v : args[:name]
       @pid_file              = args[:pid_file]
       @min_workers           = args[:min_workers]
       @max_workers           = args[:max_workers]

--- a/test/system/daemon_tests.rb
+++ b/test/system/daemon_tests.rb
@@ -270,6 +270,24 @@ module Qs::Daemon
 
   end
 
+  class WithEnvProcessLabelTests < SystemTests
+    desc "with a process label env var"
+    setup do
+      ENV['QS_PROCESS_LABEL'] = Factory.string
+
+      @daemon = AppDaemon.new
+    end
+    teardown do
+      ENV.delete('QS_PROCESS_LABEL')
+    end
+    subject{ @daemon }
+
+    should "set the daemons process label to the env var" do
+      assert_equal ENV['QS_PROCESS_LABEL'], subject.process_label
+    end
+
+  end
+
   class DaemonRunner
     def initialize(app_daemon, dispatcher_daemon = nil)
       @app_daemon = app_daemon


### PR DESCRIPTION
This moves using the process label env var into the daemon data.
This is being done because the process label shouldn't be a default
but should be used no matter the configuration. We don't currently
allow configuring a process label, but if we ever do, we want to
make sure the env var is used instead of the configuration.

Functionally, this doesn't change any of qs current behavior. The
process label will use the env var if set and if not it will use
the configured daemon name.

This is related to redding/sanford#162. We did the same changes to
the sanford ip and port env vars. This fixed a bug with the server
not using the ip and port env vars correctly.

@kellyredding - Ready for review.