### PR TITLE
message handler: make default `run!` method a no-op

### DIFF
--- a/lib/qs/message_handler.rb
+++ b/lib/qs/message_handler.rb
@@ -31,7 +31,6 @@ module Qs
       end
 
       def run!
-        raise NotImplementedError
       end
 
       def ==(other_handler)

--- a/test/unit/message_handler_tests.rb
+++ b/test/unit/message_handler_tests.rb
@@ -177,10 +177,6 @@ module Qs::MessageHandler
       assert_equal 5, subject.second_after_run_call_order
     end
 
-    should "raise a not implemented error when `run!` by default" do
-      assert_raises(NotImplementedError){ @handler_class.new(@runner).run! }
-    end
-
     should "know if it is equal to another message handler" do
       handler = TestMessageHandler.new(@runner)
       assert_equal handler, subject


### PR DESCRIPTION
This allows you to implement all run related behavior in callbacks
only if you choose.  This is ideal if you need to put run logic
into handler mixins but want to use callbacks b/c you aren't sure
what other handler mixins may be in play.

@jcredding ready for review.