### PR TITLE
message handler: make run callback method public; use in qs runner

### DIFF
--- a/lib/qs/message_handler.rb
+++ b/lib/qs/message_handler.rb
@@ -16,21 +16,27 @@ module Qs
       end
 
       def init
-        run_callback 'before_init'
+        self.qs_run_callback 'before_init'
         self.init!
-        run_callback 'after_init'
+        self.qs_run_callback 'after_init'
       end
 
       def init!
       end
 
       def run
-        run_callback 'before_run'
+        self.qs_run_callback 'before_run'
         self.run!
-        run_callback 'after_run'
+        self.qs_run_callback 'after_run'
       end
 
       def run!
+      end
+
+      def qs_run_callback(callback)
+        (self.class.send("#{callback}_callbacks") || []).each do |callback|
+          self.instance_eval(&callback)
+        end
       end
 
       def ==(other_handler)
@@ -41,14 +47,8 @@ module Qs
 
       # Helpers
 
-      def params; @qs_runner.params; end
       def logger; @qs_runner.logger; end
-
-      def run_callback(callback)
-        (self.class.send("#{callback}_callbacks") || []).each do |callback|
-          self.instance_eval(&callback)
-        end
-      end
+      def params; @qs_runner.params; end
 
     end
 

--- a/lib/qs/qs_runner.rb
+++ b/lib/qs/qs_runner.rb
@@ -15,10 +15,10 @@ module Qs
 
     def run
       OptionalTimeout.new(self.timeout) do
-        run_callbacks self.handler_class.before_callbacks
+        self.handler.qs_run_callback 'before'
         self.handler.init
         self.handler.run
-        run_callbacks self.handler_class.after_callbacks
+        self.handler.qs_run_callback 'after'
       end
     rescue TimeoutError => exception
       error = TimeoutError.new "#{handler_class} timed out (#{timeout}s)"
@@ -27,10 +27,6 @@ module Qs
     end
 
     private
-
-    def run_callbacks(callbacks)
-      callbacks.each{ |proc| self.handler.instance_eval(&proc) }
-    end
 
     module OptionalTimeout
       def self.new(timeout, &block)

--- a/test/unit/message_handler_tests.rb
+++ b/test/unit/message_handler_tests.rb
@@ -153,6 +153,7 @@ module Qs::MessageHandler
     subject{ @handler }
 
     should have_imeths :init, :init!, :run, :run!
+    should have_imeths :qs_run_callback
 
     should "know its params and logger" do
       assert_equal @runner.params, subject.public_params
@@ -175,6 +176,12 @@ module Qs::MessageHandler
       assert_equal 3, subject.run_call_order
       assert_equal 4, subject.first_after_run_call_order
       assert_equal 5, subject.second_after_run_call_order
+    end
+
+    should "run its callbacks with `qs_run_callback`" do
+      subject.qs_run_callback 'before_run'
+      assert_equal 1, subject.first_before_run_call_order
+      assert_equal 2, subject.second_before_run_call_order
     end
 
     should "know if it is equal to another message handler" do


### PR DESCRIPTION
This removes some duplication between the message handler and the
qs runner.  The qs runner needs to run some handler callbacks but
was re-implementing the run callback logic.  The handler should
own this logic and be the central location for it.

To fix this, I namespaces the run callback method with `qs_` and
made it public.  Since it is namespaced, I don't feel bad making
it public.  Now that it is public, the qs runner can call it directly.

This is just a cleanup and has no overall behavior changes.  This
is also prep for namespacing all non-user-facing methods in the
message handlers, which I will tackle in a coming effort.

@jcredding ready for review.