### PR TITLE
cleanups: consistency with Deas and Sanford; namespace handler meths

### DIFF
--- a/lib/qs/message_handler.rb
+++ b/lib/qs/message_handler.rb
@@ -15,7 +15,7 @@ module Qs
         @qs_runner = runner
       end
 
-      def init
+      def qs_init
         self.qs_run_callback 'before_init'
         self.init!
         self.qs_run_callback 'after_init'
@@ -24,7 +24,7 @@ module Qs
       def init!
       end
 
-      def run
+      def qs_run
         self.qs_run_callback 'before_run'
         self.run!
         self.qs_run_callback 'after_run'

--- a/lib/qs/qs_runner.rb
+++ b/lib/qs/qs_runner.rb
@@ -16,8 +16,8 @@ module Qs
     def run
       OptionalTimeout.new(self.timeout) do
         self.handler.qs_run_callback 'before'
-        self.handler.init
-        self.handler.run
+        self.handler.qs_init
+        self.handler.qs_run
         self.handler.qs_run_callback 'after'
       end
     rescue TimeoutError => exception

--- a/lib/qs/test_runner.rb
+++ b/lib/qs/test_runner.rb
@@ -17,11 +17,11 @@ module Qs
       })
       a.each{ |key, value| self.handler.send("#{key}=", value) }
 
-      self.handler.init
+      self.handler.qs_init
     end
 
     def run
-      self.handler.run
+      self.handler.qs_run
     end
 
     private

--- a/test/support/message_handler.rb
+++ b/test/support/message_handler.rb
@@ -1,0 +1,17 @@
+require 'qs/message_handler'
+require 'qs/test_runner'
+
+# manually define some test helpers since we don't provide helpers for
+# general message handlers as the user facing helpers are the job/event ones
+
+module Qs::MessageHandler
+
+  module TestHelpers
+
+    def test_runner(handler_class, args = nil)
+      Qs::TestRunner.new(handler_class, args)
+    end
+
+  end
+
+end

--- a/test/unit/qs_runner_tests.rb
+++ b/test/unit/qs_runner_tests.rb
@@ -66,17 +66,17 @@ class Qs::QsRunner
       assert_equal [@runner.timeout], @timeout_called_with
     end
 
-    should "run the handlers before callbacks" do
+    should "run the handler's before callbacks" do
       assert_equal 1, @handler.first_before_call_order
       assert_equal 2, @handler.second_before_call_order
     end
 
-    should "call the handlers init and run methods" do
+    should "call the handler's init and run methods" do
       assert_equal 3, @handler.init_call_order
       assert_equal 4, @handler.run_call_order
     end
 
-    should "run the handlers after callbacks" do
+    should "run the handler's after callbacks" do
       assert_equal 5, @handler.first_after_call_order
       assert_equal 6, @handler.second_after_call_order
     end
@@ -157,10 +157,8 @@ class Qs::QsRunner
 
     private
 
-    def next_call_order
-      @order ||= 0
-      @order += 1
-    end
+    def next_call_order; @order ||= 0; @order += 1; end
+
   end
 
 end

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -40,16 +40,16 @@ class Qs::Runner
 
     should "know its attrs" do
       args = {
+        :logger  => Factory.string,
         :message => Factory.string,
-        :params  => Factory.string,
-        :logger  => Factory.string
+        :params  => Factory.string
       }
 
       runner = @runner_class.new(@handler_class, args)
 
+      assert_equal args[:logger],  runner.logger
       assert_equal args[:message], runner.message
       assert_equal args[:params],  runner.params
-      assert_equal args[:logger],  runner.logger
     end
 
     should "not implement its run method" do

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -28,10 +28,10 @@ class Qs::TestRunner
     setup do
       @handler_class = TestMessageHandler
       @args = {
-        :logger  => Factory.string,
-        :message => Factory.message,
-        :params  => { Factory.string => Factory.string },
-        :flag    => Factory.boolean
+        :logger       => Factory.string,
+        :message      => Factory.message,
+        :params       => { Factory.string => Factory.string },
+        :custom_value => Factory.integer
       }
       @original_args = @args.dup
       @runner  = @runner_class.new(@handler_class, @args)
@@ -41,33 +41,33 @@ class Qs::TestRunner
 
     should have_imeths :run
 
-    should "super its standard args" do
+    should "know its standard args" do
       assert_equal @args[:logger],  subject.logger
       assert_equal @args[:message], subject.message
       assert_equal @args[:params],  subject.params
     end
 
-    should "write extra args to its message handler" do
-      assert_equal @args[:flag], @handler.flag
+    should "write any non-standard args to its handler" do
+      assert_equal @args[:custom_value], @handler.custom_value
     end
 
     should "not alter the args passed to it" do
       assert_equal @original_args, @args
     end
 
-    should "not call its message handler's before callbacks" do
+    should "not call its handler's before callbacks" do
       assert_nil @handler.before_called
     end
 
-    should "call its message handler's init" do
+    should "call its handler's init" do
       assert_true @handler.init_called
     end
 
-    should "not run its message handler" do
+    should "not call its handler's run" do
       assert_nil @handler.run_called
     end
 
-    should "not call its message handler's after callbacks" do
+    should "not call its handler's after callbacks" do
       assert_nil @handler.after_called
     end
 
@@ -194,7 +194,7 @@ class Qs::TestRunner
 
     attr_reader :before_called, :after_called
     attr_reader :init_called, :run_called
-    attr_accessor :flag
+    attr_accessor :custom_value
 
     before{ @before_called = true }
     after{ @after_called = true }
@@ -206,6 +206,7 @@ class Qs::TestRunner
     def run!
       @run_called = true
     end
+
   end
 
   class TestJobHandler


### PR DESCRIPTION
This touches up a bunch of minor things to get Qs' handler pattern
implementation/tests consistent with Deas' and Sanford's.

In additon, this namespaces non-user-facing methods in the message
handler.  Since handlers are intended to run user code, we want to be
careful to not "pollute" the handler scope with our own methods that
will break in spectacular ways if the user happens to override them.
This switches the `init` and `run` (ie the two methods not intended
to be called or used by users) to be prefixed with `qs_`.  This not
only marks them as internal "qs" methods but also makes it more
difficult to accidentally override them in custom user handlers.

@jcredding ready for review.