### PR TITLE
Update to use the new dat-worker-pool

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ gemspec
 gem 'rake'
 gem 'pry', "~> 0.9.0"
 
+gem 'dat-worker-pool', :path => "~/Projects/redding/gems/dat-worker-pool"
+
 platform :ruby_18 do
   gem 'json', '~> 1.8'
 end

--- a/bench/report.rb
+++ b/bench/report.rb
@@ -53,12 +53,12 @@ class BenchRunner
 
     size = @results.values.map(&:size).max
     output "\n", false
-    output "Enqueueing #{@number_of_jobs} Jobs Time: #{@results[:enqueueing_jobs].rjust(size)}"
-    output "Running #{@number_of_jobs} Jobs Time:    #{@results[:running_jobs].rjust(size)}"
+    output "Enqueueing #{@number_of_jobs} Jobs Time: #{@results[:enqueueing_jobs].rjust(size)}s"
+    output "Running #{@number_of_jobs} Jobs Time:    #{@results[:running_jobs].rjust(size)}s"
 
     output "\n", false
-    output "Publishing #{@number_of_events} Events Time: #{@results[:publishing_events].rjust(size)}"
-    output "Running #{@number_of_events} Events Time:    #{@results[:running_events].rjust(size)}"
+    output "Publishing #{@number_of_events} Events Time: #{@results[:publishing_events].rjust(size)}s"
+    output "Running #{@number_of_events} Events Time:    #{@results[:running_events].rjust(size)}s"
 
     output "\n"
     output "Done running benchmark report"

--- a/bench/report.txt
+++ b/bench/report.txt
@@ -9,10 +9,10 @@ Publishing events
 Running events
 ....................................................................................................
 
-Enqueueing 10000 Jobs Time:  1.6858
-Running 10000 Jobs Time:    11.3011
+Enqueueing 10000 Jobs Time:  1.7498s
+Running 10000 Jobs Time:    13.0530s
 
-Publishing 10000 Events Time:  2.4596
-Running 10000 Events Time:    16.0522
+Publishing 10000 Events Time:  2.6319s
+Running 10000 Events Time:    17.8165s
 
 Done running benchmark report

--- a/lib/qs/daemon_data.rb
+++ b/lib/qs/daemon_data.rb
@@ -9,9 +9,8 @@ module Qs
 
     attr_reader :name, :process_label
     attr_reader :pid_file
-    attr_reader :min_workers, :max_workers
-    attr_reader :worker_start_procs, :worker_shutdown_procs
-    attr_reader :worker_sleep_procs, :worker_wakeup_procs
+    attr_reader :worker_class, :worker_params
+    attr_reader :num_workers
     attr_reader :logger, :verbose_logging
     attr_reader :shutdown_timeout
     attr_reader :error_procs
@@ -19,21 +18,18 @@ module Qs
 
     def initialize(args = nil)
       args ||= {}
-      @name                  = args[:name]
-      @process_label         = !(v = ENV['QS_PROCESS_LABEL'].to_s).empty? ? v : args[:name]
-      @pid_file              = args[:pid_file]
-      @min_workers           = args[:min_workers]
-      @max_workers           = args[:max_workers]
-      @worker_start_procs    = args[:worker_start_procs]
-      @worker_shutdown_procs = args[:worker_shutdown_procs]
-      @worker_sleep_procs    = args[:worker_sleep_procs]
-      @worker_wakeup_procs   = args[:worker_wakeup_procs]
-      @logger                = args[:logger]
-      @verbose_logging       = !!args[:verbose_logging]
-      @shutdown_timeout      = args[:shutdown_timeout]
-      @error_procs           = args[:error_procs] || []
-      @queue_redis_keys      = args[:queue_redis_keys] || []
-      @routes                = build_routes(args[:routes] || [])
+      @name             = args[:name]
+      @process_label    = !(v = ENV['QS_PROCESS_LABEL'].to_s).empty? ? v : args[:name]
+      @pid_file         = args[:pid_file]
+      @worker_class     = args[:worker_class]
+      @worker_params    = args[:worker_params] || {}
+      @num_workers      = args[:num_workers]
+      @logger           = args[:logger]
+      @verbose_logging  = !!args[:verbose_logging]
+      @shutdown_timeout = args[:shutdown_timeout]
+      @error_procs      = args[:error_procs] || []
+      @queue_redis_keys = args[:queue_redis_keys] || []
+      @routes           = build_routes(args[:routes] || [])
     end
 
     def route_for(route_id)

--- a/lib/qs/worker.rb
+++ b/lib/qs/worker.rb
@@ -1,0 +1,66 @@
+require 'dat-worker-pool/worker'
+require 'qs/payload_handler'
+
+module Qs
+
+  module Worker
+
+    IVAR_NAME = "@qs_worker_mixin_included_already".freeze
+
+    def self.included(klass)
+      return if klass.instance_variable_get(IVAR_NAME)
+
+      klass.class_eval do
+        include DatWorkerPool::Worker
+        include InstanceMethods
+
+        on_available{ params[:qs_worker_available].signal }
+
+        on_error{ |e, wi| qs_handle_exception(e, wi) }
+
+      end
+
+      klass.instance_variable_set(IVAR_NAME, true)
+    end
+
+    module InstanceMethods
+
+      def work!(queue_item)
+        Qs::PayloadHandler.new(params[:qs_daemon_data], queue_item).run
+      end
+
+      private
+
+      # this only catches errors that happen outside of running the payload
+      # handler, the only known use-case for this is dwps shutdown errors; if
+      # there isn't a queue item (this can happen when an idle worker is being
+      # forced to exit) then we don't need to do anything; if we never started
+      # processing the queue item, its safe to requeue it, otherwise it happened
+      # while it was being processed (by the payload handler) or after it was
+      # processed, for these cases, either the payload handler caught the error
+      # (while it was being processed) or we don't care because its been
+      # processed and the worker is just finishing up
+      def qs_handle_exception(exception, queue_item)
+        return if queue_item.nil?
+        if !queue_item.started
+          qs_log "Worker error, requeueing message because it hasn't started", :error
+          params[:qs_client].prepend(
+            queue_item.queue_redis_key,
+            queue_item.encoded_payload
+          )
+        else
+          qs_log "Worker error after message was processed, ignoring", :error
+        end
+        qs_log "#{exception.class}: #{exception.message}", :error
+        qs_log (exception.backtrace || []).join("\n"), :error
+      end
+
+      def qs_log(message, level = :info)
+        params[:qs_logger].send(level, "[Qs-#{number}] #{message}")
+      end
+
+    end
+
+  end
+
+end

--- a/test/support/client_spy.rb
+++ b/test/support/client_spy.rb
@@ -1,0 +1,43 @@
+require 'qs/client'
+
+class ClientSpy < Qs::TestClient
+  attr_reader :calls
+
+  def initialize(redis_config = nil)
+    super(redis_config || {})
+    @calls = []
+    @list  = []
+    @mutex = Mutex.new
+    @cv    = ConditionVariable.new
+  end
+
+  def block_dequeue(*args)
+    @calls << Call.new(:block_dequeue, args)
+    if @list.empty?
+      @mutex.synchronize{ @cv.wait(@mutex) }
+    end
+    @list.shift
+  end
+
+  def append(*args)
+    @calls << Call.new(:append, args)
+    @list  << args
+    @cv.signal
+  end
+
+  def prepend(*args)
+    @calls << Call.new(:prepend, args)
+    @list  << args
+    @cv.signal
+  end
+
+  def clear(*args)
+    @calls << Call.new(:clear, args)
+  end
+
+  def ping
+    @calls << Call.new(:ping)
+  end
+
+  Call = Struct.new(:command, :args)
+end

--- a/test/system/daemon_tests.rb
+++ b/test/system/daemon_tests.rb
@@ -144,27 +144,6 @@ module Qs::Daemon
 
   end
 
-  class NoWorkersAvailableTests < SystemTests
-    desc "when no workers are available"
-    setup do
-      AppDaemon.workers 0 # no workers available, don't do this
-      setup_app_and_dispatcher_daemon
-    end
-
-    should "shutdown when stopped" do
-      @app_daemon.stop
-      @app_thread.join 2 # give it time to shutdown, should be faster
-      assert_false @app_thread.alive?
-    end
-
-    should "shutdown when halted" do
-      @app_daemon.halt
-      @app_thread.join 2 # give it time to shutdown, should be faster
-      assert_false @app_thread.alive?
-    end
-
-  end
-
   class ShutdownWithoutTimeoutTests < SystemTests
     desc "without a shutdown timeout"
     setup do

--- a/test/unit/daemon_data_tests.rb
+++ b/test/unit/daemon_data_tests.rb
@@ -17,20 +17,17 @@ class Qs::DaemonData
       end
 
       @config_hash = {
-        :name                  => Factory.string,
-        :pid_file              => Factory.file_path,
-        :min_workers           => Factory.integer,
-        :max_workers           => Factory.integer,
-        :worker_start_procs    => Factory.integer(3).times.map{ proc{} },
-        :worker_shutdown_procs => Factory.integer(3).times.map{ proc{} },
-        :worker_sleep_procs    => Factory.integer(3).times.map{ proc{} },
-        :worker_wakeup_procs   => Factory.integer(3).times.map{ proc{} },
-        :logger                => Factory.string,
-        :verbose_logging       => Factory.boolean,
-        :shutdown_timeout      => Factory.integer,
-        :error_procs           => [ proc{ Factory.string } ],
-        :queue_redis_keys      => Factory.integer(3).times.map{ Factory.string },
-        :routes                => @routes
+        :name             => Factory.string,
+        :pid_file         => Factory.file_path,
+        :worker_class     => Class.new,
+        :worker_params    => { Factory.string => Factory.string },
+        :num_workers      => Factory.integer,
+        :logger           => Factory.string,
+        :verbose_logging  => Factory.boolean,
+        :shutdown_timeout => Factory.integer,
+        :error_procs      => [ proc{ Factory.string } ],
+        :queue_redis_keys => Factory.integer(3).times.map{ Factory.string },
+        :routes           => @routes
       }
       @daemon_data = Qs::DaemonData.new(@config_hash)
     end
@@ -41,9 +38,8 @@ class Qs::DaemonData
 
     should have_readers :name, :process_label
     should have_readers :pid_file
-    should have_readers :min_workers, :max_workers
-    should have_readers :worker_start_procs, :worker_shutdown_procs
-    should have_readers :worker_sleep_procs, :worker_wakeup_procs
+    should have_readers :worker_class, :worker_params
+    should have_readers :num_workers
     should have_readers :logger, :verbose_logging
     should have_readers :shutdown_timeout
     should have_readers :error_procs
@@ -52,19 +48,16 @@ class Qs::DaemonData
 
     should "know its attributes" do
       h = @config_hash
-      assert_equal h[:name],                  subject.name
-      assert_equal h[:pid_file],              subject.pid_file
-      assert_equal h[:min_workers],           subject.min_workers
-      assert_equal h[:max_workers],           subject.max_workers
-      assert_equal h[:worker_start_procs],    subject.worker_start_procs
-      assert_equal h[:worker_shutdown_procs], subject.worker_shutdown_procs
-      assert_equal h[:worker_sleep_procs],    subject.worker_sleep_procs
-      assert_equal h[:worker_wakeup_procs],   subject.worker_wakeup_procs
-      assert_equal h[:logger],                subject.logger
-      assert_equal h[:verbose_logging],       subject.verbose_logging
-      assert_equal h[:shutdown_timeout],      subject.shutdown_timeout
-      assert_equal h[:error_procs],           subject.error_procs
-      assert_equal h[:queue_redis_keys],      subject.queue_redis_keys
+      assert_equal h[:name],             subject.name
+      assert_equal h[:pid_file],         subject.pid_file
+      assert_equal h[:worker_class],     subject.worker_class
+      assert_equal h[:worker_params],    subject.worker_params
+      assert_equal h[:num_workers],      subject.num_workers
+      assert_equal h[:logger],           subject.logger
+      assert_equal h[:verbose_logging],  subject.verbose_logging
+      assert_equal h[:shutdown_timeout], subject.shutdown_timeout
+      assert_equal h[:error_procs],      subject.error_procs
+      assert_equal h[:queue_redis_keys], subject.queue_redis_keys
     end
 
     should "use process label env var if set" do
@@ -102,8 +95,9 @@ class Qs::DaemonData
       daemon_data = Qs::DaemonData.new
       assert_nil daemon_data.name
       assert_nil daemon_data.pid_file
-      assert_nil daemon_data.min_workers
-      assert_nil daemon_data.max_workers
+      assert_nil daemon_data.worker_class
+      assert_equal({}, daemon_data.worker_params)
+      assert_nil daemon_data.num_workers
       assert_nil daemon_data.logger
       assert_false daemon_data.verbose_logging
       assert_nil daemon_data.shutdown_timeout

--- a/test/unit/daemon_tests.rb
+++ b/test/unit/daemon_tests.rb
@@ -7,6 +7,7 @@ require 'thread'
 require 'qs/client'
 require 'qs/queue'
 require 'qs/queue_item'
+require 'test/support/client_spy'
 
 module Qs::Daemon
 
@@ -19,9 +20,8 @@ module Qs::Daemon
 
     should have_imeths :configuration
     should have_imeths :name, :pid_file
-    should have_imeths :min_workers, :max_workers, :workers
-    should have_imeths :on_worker_start, :on_worker_shutdown
-    should have_imeths :on_worker_sleep, :on_worker_wakeup
+    should have_imeths :worker_class, :worker_params
+    should have_imeths :num_workers, :workers
     should have_imeths :verbose_logging, :logger
     should have_imeths :shutdown_timeout
     should have_imeths :init, :error, :queue
@@ -47,43 +47,32 @@ module Qs::Daemon
       assert_equal expected, subject.pid_file
     end
 
-    should "allow reading/writing its configuration min workers" do
-      new_min_workers = Factory.integer
-      subject.min_workers(new_min_workers)
-      assert_equal new_min_workers, subject.configuration.min_workers
-      assert_equal new_min_workers, subject.min_workers
+    should "allow reading/writing its configuration worker class" do
+      new_worker_class = Class.new
+      subject.worker_class(new_worker_class)
+      assert_equal new_worker_class, subject.configuration.worker_class
+      assert_equal new_worker_class, subject.worker_class
     end
 
-    should "allow reading/writing its configuration max workers" do
-      new_max_workers = Factory.integer
-      subject.max_workers(new_max_workers)
-      assert_equal new_max_workers, subject.configuration.max_workers
-      assert_equal new_max_workers, subject.max_workers
+    should "allow reading/writing its configuration worker params" do
+      new_worker_params = { Factory.string => Factory.string }
+      subject.worker_params(new_worker_params)
+      assert_equal new_worker_params, subject.configuration.worker_params
+      assert_equal new_worker_params, subject.worker_params
     end
 
-    should "allow reading/writing its configuration workers" do
+    should "allow reading/writing its configuration num workers" do
+      new_num_workers = Factory.integer
+      subject.num_workers(new_num_workers)
+      assert_equal new_num_workers, subject.configuration.num_workers
+      assert_equal new_num_workers, subject.num_workers
+    end
+
+    should "alias workers as num workers" do
       new_workers = Factory.integer
       subject.workers(new_workers)
-      assert_equal new_workers, subject.configuration.min_workers
-      assert_equal new_workers, subject.configuration.max_workers
-      assert_equal new_workers, subject.min_workers
-      assert_equal new_workers, subject.max_workers
-    end
-
-    should "allow reading/writing its configuration worker procs" do
-      p = proc{}
-
-      subject.on_worker_start(&p)
-      assert_equal [p], subject.configuration.worker_start_procs
-
-      subject.on_worker_shutdown(&p)
-      assert_equal [p], subject.configuration.worker_shutdown_procs
-
-      subject.on_worker_sleep(&p)
-      assert_equal [p], subject.configuration.worker_sleep_procs
-
-      subject.on_worker_wakeup(&p)
-      assert_equal [p], subject.configuration.worker_wakeup_procs
+      assert_equal new_workers, subject.configuration.num_workers
+      assert_equal new_workers, subject.workers
     end
 
     should "allow reading/writing its configuration verbose logging" do
@@ -134,19 +123,11 @@ module Qs::Daemon
 
       @daemon_class.name Factory.string
       @daemon_class.pid_file Factory.file_path
+      @daemon_class.worker_params(Factory.string => Factory.string)
       @daemon_class.workers Factory.integer
       @daemon_class.verbose_logging Factory.boolean
       @daemon_class.shutdown_timeout Factory.integer
       @daemon_class.error{ Factory.string }
-
-      @start_procs    = Factory.integer(3).times.map{ proc{} }
-      @shutdown_procs = Factory.integer(3).times.map{ proc{} }
-      @sleep_procs    = Factory.integer(3).times.map{ proc{} }
-      @wakeup_procs   = Factory.integer(3).times.map{ proc{} }
-      @start_procs.each    { |p| @daemon_class.on_worker_start(&p) }
-      @shutdown_procs.each { |p| @daemon_class.on_worker_shutdown(&p) }
-      @sleep_procs.each    { |p| @daemon_class.on_worker_sleep(&p) }
-      @wakeup_procs.each   { |p| @daemon_class.on_worker_wakeup(&p) }
 
       @queue = Qs::Queue.new do
         name(Factory.string)
@@ -159,12 +140,15 @@ module Qs::Daemon
         @client_spy = ClientSpy.new(*args)
       end
 
-      @worker_pool_spy = nil
-      @worker_available = true
-      Assert.stub(::DatWorkerPool, :new) do |*args, &block|
-        @worker_pool_spy = DatWorkerPool::WorkerPoolSpy.new(*args, &block)
-        @worker_pool_spy.worker_available = !!@worker_available
-        @worker_pool_spy
+      @worker_available = WorkerAvailable.new
+      Assert.stub(WorkerAvailable, :new){ @worker_available }
+
+      @wp_spy             = nil
+      @wp_worker_available = true
+      Assert.stub(DatWorkerPool, :new) do |*args|
+        @wp_spy = DatWorkerPool::WorkerPoolSpy.new(*args)
+        @wp_spy.worker_available = !!@wp_worker_available
+        @wp_spy
       end
     end
     teardown do
@@ -199,15 +183,11 @@ module Qs::Daemon
       data = subject.daemon_data
 
       assert_instance_of Qs::DaemonData, data
-      assert_equal configuration.name,        data.name
-      assert_equal configuration.pid_file,    data.pid_file
-      assert_equal configuration.min_workers, data.min_workers
-      assert_equal configuration.max_workers, data.max_workers
-
-      assert_equal configuration.worker_start_procs,    data.worker_start_procs
-      assert_equal configuration.worker_shutdown_procs, data.worker_shutdown_procs
-      assert_equal configuration.worker_sleep_procs,    data.worker_sleep_procs
-      assert_equal configuration.worker_wakeup_procs,   data.worker_wakeup_procs
+      assert_equal configuration.name,          data.name
+      assert_equal configuration.pid_file,      data.pid_file
+      assert_equal configuration.worker_class,  data.worker_class
+      assert_equal configuration.worker_params, data.worker_params
+      assert_equal configuration.num_workers,   data.num_workers
 
       assert_equal configuration.verbose_logging,  data.verbose_logging
       assert_equal configuration.shutdown_timeout, data.shutdown_timeout
@@ -237,9 +217,25 @@ module Qs::Daemon
       assert_not_nil @client_spy
       exp = Qs.redis_config.merge({
         :timeout => 1,
-        :size    => subject.daemon_data.max_workers + 1
+        :size    => subject.daemon_data.num_workers + 1
       })
       assert_equal exp, @client_spy.redis_config
+    end
+
+    should "build a worker pool" do
+      data = subject.daemon_data
+
+      assert_not_nil @wp_spy
+      assert_equal data.worker_class, @wp_spy.worker_class
+      assert_equal data.num_workers,  @wp_spy.num_workers
+      exp = data.worker_params.merge({
+        :qs_daemon_data      => data,
+        :qs_client           => @client_spy,
+        :qs_worker_available => @worker_available,
+        :qs_logger           => data.logger
+      })
+      assert_equal exp, @wp_spy.worker_params
+      assert_false @wp_spy.start_called
     end
 
     should "not be running by default" do
@@ -275,27 +271,8 @@ module Qs::Daemon
       assert_equal [subject.signals_redis_key], call.args
     end
 
-    should "build and start a worker pool" do
-      assert_not_nil @worker_pool_spy
-      assert_equal @daemon_class.min_workers, @worker_pool_spy.min_workers
-      assert_equal @daemon_class.max_workers, @worker_pool_spy.max_workers
-
-      exp = 1
-      assert_equal exp, @worker_pool_spy.on_worker_error_callbacks.size
-
-      exp = @start_procs.size
-      assert_equal exp, @worker_pool_spy.on_worker_start_callbacks.size
-
-      exp = @shutdown_procs.size
-      assert_equal exp, @worker_pool_spy.on_worker_shutdown_callbacks.size
-
-      exp = @sleep_procs.size + 1 # configured plus 1 internal
-      assert_equal exp, @worker_pool_spy.on_worker_sleep_callbacks.size
-
-      exp = @wakeup_procs.size
-      assert_equal exp, @worker_pool_spy.on_worker_wakeup_callbacks.size
-
-      assert_true @worker_pool_spy.start_called
+    should "start its worker pool" do
+      assert_true @wp_spy.start_called
     end
 
   end
@@ -303,7 +280,7 @@ module Qs::Daemon
   class RunningWithoutAvailableWorkerTests < InitSetupTests
     desc "running without an available worker"
     setup do
-      @worker_available = false
+      @wp_worker_available = false
 
       @daemon = @daemon_class.new
       @thread = @daemon.start
@@ -315,7 +292,7 @@ module Qs::Daemon
       assert_equal 'sleep', @thread.status
       @client_spy.append(@queue.redis_key, Factory.string)
       @thread.join(0.1)
-      assert_empty @worker_pool_spy.work_items
+      assert_empty @wp_spy.work_items
     end
 
   end
@@ -337,7 +314,7 @@ module Qs::Daemon
       exp = [subject.signals_redis_key, subject.queue_redis_keys, 0].flatten
       assert_equal exp, call.args
       exp = Qs::QueueItem.new(@queue.redis_key, @encoded_payload)
-      assert_equal exp, @worker_pool_spy.work_items.first
+      assert_equal exp, @wp_spy.work_items.first
     end
 
   end
@@ -393,75 +370,18 @@ module Qs::Daemon
 
   end
 
-  class WorkerPoolWorkProcTests < InitSetupTests
-    desc "worker pool work proc"
-    setup do
-      @ph_spy = nil
-      Assert.stub(Qs::PayloadHandler, :new) do |*args|
-        @ph_spy = PayloadHandlerSpy.new(*args)
-      end
-
-      @daemon = @daemon_class.new
-      @thread = @daemon.start
-
-      @queue_item = Qs::QueueItem.new(Factory.string, Factory.string)
-      @worker_pool_spy.work_proc.call(@queue_item)
-    end
-    subject{ @daemon }
-
-    should "build and run a payload handler" do
-      assert_not_nil @ph_spy
-      assert_equal subject.daemon_data, @ph_spy.daemon_data
-      assert_equal @queue_item,         @ph_spy.queue_item
-    end
-
-  end
-
-  class WorkerPoolOnWorkerErrorTests < InitSetupTests
-    desc "worker pool on worker error proc"
-    setup do
-      @daemon = @daemon_class.new
-      @thread = @daemon.start
-
-      @exception  = Factory.exception
-      @queue_item = Qs::QueueItem.new(Factory.string, Factory.string)
-      @callback   = @worker_pool_spy.on_worker_error_callbacks.first
-    end
-    subject{ @daemon }
-
-    should "requeue the queue item if it wasn't started" do
-      @queue_item.started = false
-      @callback.call('worker', @exception, @queue_item)
-      call = @client_spy.calls.detect{ |c| c.command == :prepend }
-      assert_not_nil call
-      assert_equal @queue_item.queue_redis_key, call.args.first
-      assert_equal @queue_item.encoded_payload, call.args.last
-    end
-
-    should "not requeue the queue item if it was started" do
-      @queue_item.started = true
-      @callback.call('worker', @exception, @queue_item)
-      assert_nil @client_spy.calls.detect{ |c| c.command == :prepend }
-    end
-
-    should "do nothing if not passed a queue item" do
-      assert_nothing_raised{ @callback.call(@exception, nil) }
-    end
-
-  end
-
   class StopTests < StartTests
     desc "and then stopped"
     setup do
       @queue_item = Qs::QueueItem.new(@queue.redis_key, Factory.string)
-      @worker_pool_spy.add_work(@queue_item)
+      @wp_spy.push(@queue_item)
 
       @daemon.stop true
     end
 
     should "shutdown the worker pool" do
-      assert_true @worker_pool_spy.shutdown_called
-      assert_equal @daemon_class.shutdown_timeout, @worker_pool_spy.shutdown_timeout
+      assert_true @wp_spy.shutdown_called
+      assert_equal @daemon_class.shutdown_timeout, @wp_spy.shutdown_timeout
     end
 
     should "requeue any work left on the pool" do
@@ -484,7 +404,7 @@ module Qs::Daemon
   class StopWhileWaitingForWorkerTests < InitSetupTests
     desc "stopped while waiting for a worker"
     setup do
-      @worker_available = false
+      @wp_worker_available = false
       @daemon = @daemon_class.new
       @thread = @daemon.start
       @daemon.stop(true)
@@ -501,14 +421,14 @@ module Qs::Daemon
     desc "and then halted"
     setup do
       @queue_item = Qs::QueueItem.new(@queue.redis_key, Factory.string)
-      @worker_pool_spy.add_work(@queue_item)
+      @wp_spy.push(@queue_item)
 
       @daemon.halt true
     end
 
     should "shutdown the worker pool with a 0 timeout" do
-      assert_true @worker_pool_spy.shutdown_called
-      assert_equal 0, @worker_pool_spy.shutdown_timeout
+      assert_true @wp_spy.shutdown_called
+      assert_equal 0, @wp_spy.shutdown_timeout
     end
 
     should "requeue any work left on the pool" do
@@ -531,7 +451,7 @@ module Qs::Daemon
   class HaltWhileWaitingForWorkerTests < InitSetupTests
     desc "halted while waiting for a worker"
     setup do
-      @worker_available = false
+      @wp_worker_available = false
       @daemon = @daemon_class.new
       @thread = @daemon.start
       @daemon.halt(true)
@@ -548,17 +468,18 @@ module Qs::Daemon
     desc "with a work loop error"
     setup do
       # cause a non-dequeue error
-      Assert.stub(@worker_pool_spy, :worker_available?){ raise RuntimeError }
+      Assert.stub(@wp_spy, :worker_available?){ raise RuntimeError }
 
-      # cause the daemon to loop, its sleeping on the original block_dequeue
+      # cause the daemon to loop, it's sleeping on the original `block_dequeue`
       # call that happened before the stub
       @queue_item = Qs::QueueItem.new(@queue.redis_key, Factory.string)
       @client_spy.append(@queue_item.queue_redis_key, @queue_item.encoded_payload)
+      @thread.join
     end
 
     should "shutdown the worker pool" do
-      assert_true @worker_pool_spy.shutdown_called
-      assert_equal @daemon_class.shutdown_timeout, @worker_pool_spy.shutdown_timeout
+      assert_true @wp_spy.shutdown_called
+      assert_equal @daemon_class.shutdown_timeout, @wp_spy.shutdown_timeout
     end
 
     should "requeue any work left on the pool" do
@@ -597,13 +518,12 @@ module Qs::Daemon
     subject{ @configuration }
 
     should have_options :name, :pid_file
-    should have_options :min_workers, :max_workers
+    should have_options :num_workers
     should have_options :verbose_logging, :logger
     should have_options :shutdown_timeout
     should have_accessors :init_procs, :error_procs
+    should have_accessors :worker_class, :worker_params
     should have_accessors :queues
-    should have_readers :worker_start_procs, :worker_shutdown_procs
-    should have_readers :worker_sleep_procs, :worker_wakeup_procs
     should have_imeths :routes
     should have_imeths :to_hash
     should have_imeths :valid?, :validate!
@@ -616,18 +536,15 @@ module Qs::Daemon
       config = Configuration.new
       assert_nil config.name
       assert_nil config.pid_file
-      assert_equal 1, config.min_workers
-      assert_equal 4, config.max_workers
+      assert_equal 4, config.num_workers
       assert_true config.verbose_logging
       assert_instance_of Qs::NullLogger, config.logger
       assert_nil subject.shutdown_timeout
 
       assert_equal [], config.init_procs
       assert_equal [], config.error_procs
-      assert_equal [], subject.worker_start_procs
-      assert_equal [], subject.worker_shutdown_procs
-      assert_equal [], subject.worker_sleep_procs
-      assert_equal [], subject.worker_wakeup_procs
+      assert_equal DefaultWorker, config.worker_class
+      assert_nil config.worker_params
       assert_equal [], config.queues
       assert_equal [], config.routes
     end
@@ -643,16 +560,13 @@ module Qs::Daemon
     should "include some attrs (not just the options) in its hash" do
       config_hash = subject.to_hash
 
-      assert_equal subject.error_procs, config_hash[:error_procs]
-      assert_equal subject.routes,      config_hash[:routes]
+      assert_equal subject.error_procs,   config_hash[:error_procs]
+      assert_equal subject.worker_class,  config_hash[:worker_class]
+      assert_equal subject.worker_params, config_hash[:worker_params]
+      assert_equal subject.routes,        config_hash[:routes]
 
       exp = subject.queues.map(&:redis_key)
       assert_equal exp, config_hash[:queue_redis_keys]
-
-      assert_equal subject.worker_start_procs,    config_hash[:worker_start_procs]
-      assert_equal subject.worker_shutdown_procs, config_hash[:worker_shutdown_procs]
-      assert_equal subject.worker_sleep_procs,    config_hash[:worker_sleep_procs]
-      assert_equal subject.worker_wakeup_procs,   config_hash[:worker_wakeup_procs]
     end
 
     should "call its init procs when validated" do
@@ -678,6 +592,14 @@ module Qs::Daemon
       subject.routes.each{ |route| assert_nil route.handler_class }
       subject.validate!
       subject.routes.each{ |route| assert_not_nil route.handler_class }
+    end
+
+    should "validate its worker class when validated" do
+      subject.worker_class = Module.new
+      assert_raises(InvalidError){ subject.validate! }
+
+      subject.worker_class = Class.new
+      assert_raises(InvalidError){ subject.validate! }
     end
 
     should "be valid after being validated" do
@@ -748,61 +670,5 @@ module Qs::Daemon
   end
 
   TestHandler = Class.new
-
-  class PayloadHandlerSpy
-    attr_reader :daemon_data, :queue_item, :run_called
-
-    def initialize(daemon_data, queue_item)
-      @daemon_data = daemon_data
-      @queue_item  = queue_item
-      @run_called  = false
-    end
-
-    def run
-      @run_called = true
-    end
-  end
-
-  class ClientSpy < Qs::TestClient
-    attr_reader :calls
-
-    def initialize(*args)
-      super
-      @calls = []
-      @list  = []
-      @mutex = Mutex.new
-      @cv    = ConditionVariable.new
-    end
-
-    def block_dequeue(*args)
-      @calls << Call.new(:block_dequeue, args)
-      if @list.empty?
-        @mutex.synchronize{ @cv.wait(@mutex) }
-      end
-      @list.shift
-    end
-
-    def append(*args)
-      @calls << Call.new(:append, args)
-      @list  << args
-      @cv.signal
-    end
-
-    def prepend(*args)
-      @calls << Call.new(:prepend, args)
-      @list  << args
-      @cv.signal
-    end
-
-    def clear(*args)
-      @calls << Call.new(:clear, args)
-    end
-
-    def ping
-      @calls << Call.new(:ping)
-    end
-
-    Call = Struct.new(:command, :args)
-  end
 
 end

--- a/test/unit/worker_tests.rb
+++ b/test/unit/worker_tests.rb
@@ -1,0 +1,108 @@
+require 'assert'
+require 'qs/worker'
+
+require 'dat-worker-pool/worker'
+require 'qs/daemon'
+require 'qs/daemon_data'
+require 'qs/logger'
+require 'qs/queue_item'
+require 'test/support/client_spy'
+
+module Qs::Worker
+
+  class UnitTests < Assert::Context
+    include DatWorkerPool::Worker::TestHelpers
+
+    desc "Qs::Worker"
+    setup do
+      @worker_class = Class.new{ include Qs::Worker }
+    end
+    subject{ @worker_class }
+
+    should "be a dat-worker-pool worker" do
+      assert_includes DatWorkerPool::Worker, subject
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @ph_spy = nil
+      Assert.stub(Qs::PayloadHandler, :new) do |*args|
+        @ph_spy = PayloadHandlerSpy.new(*args)
+      end
+
+      @daemon_data      = Qs::DaemonData.new
+      @client_spy       = ClientSpy.new
+      @worker_available = Qs::Daemon::WorkerAvailable.new
+      @queue_item       = Qs::QueueItem.new(Factory.string, Factory.string)
+
+      @worker_params = {
+        :qs_daemon_data      => @daemon_data,
+        :qs_client           => @client_spy,
+        :qs_worker_available => @worker_available,
+        :qs_logger           => Qs::NullLogger.new
+      }
+      @runner = test_runner(@worker_class, :params => @worker_params)
+    end
+    subject{ @runner }
+
+    should "build and run a payload handler when it processes a queue item" do
+      subject.work(@queue_item)
+
+      assert_not_nil @ph_spy
+      assert_equal @daemon_data, @ph_spy.daemon_data
+      assert_equal @queue_item,  @ph_spy.queue_item
+      assert_true @ph_spy.run_called
+    end
+
+    should "signal that a worker is available when it becomes available" do
+      signal_called = false
+      Assert.stub(@worker_available, :signal){ signal_called = true }
+
+      subject.make_available
+      assert_true signal_called
+    end
+
+    should "requeue a queue item if an error occurs before its started" do
+      exception = Factory.exception
+      @queue_item.started = false
+      subject.error(exception, @queue_item)
+
+      call = @client_spy.calls.last
+      assert_equal :prepend, call.command
+      assert_equal @queue_item.queue_redis_key, call.args.first
+      assert_equal @queue_item.encoded_payload, call.args.last
+    end
+
+    should "not requeue a queue item if an error occurs after its started" do
+      exception = Factory.exception
+      @queue_item.started = true
+      subject.error(exception, @queue_item)
+
+      assert_empty @client_spy.calls
+    end
+
+    should "do nothing if not passed a queue item" do
+      assert_nothing_raised{ subject.error(Factory.exception) }
+      assert_empty @client_spy.calls
+    end
+
+  end
+
+  class PayloadHandlerSpy
+    attr_reader :daemon_data, :queue_item, :run_called
+
+    def initialize(daemon_data, queue_item)
+      @daemon_data = daemon_data
+      @queue_item  = queue_item
+      @run_called  = false
+    end
+
+    def run
+      @run_called = true
+    end
+  end
+
+end


### PR DESCRIPTION
This updates qs to use the new dat-worker-pool. dat-worker-pool's
interface has changed but functionally it works the same as it
previously did.

A daemon can now be configured with a worker class instead of
worker procs. This is because dat-worker-pool now requires a worker
class when its initialized. A block is no longer part of
dat-worker-pool's interface. The logic for processing a work item
(a queue item for qs) is now part of the worker class that is passed
in. Worker callbacks should now be added to the worker class thats
configured.

The daemon now also builds a worker pool when its initialized
instead of waiting till its started. This was previously made
possible when dat-worker-pool was changed to not start
automatically but qs didn't take advantage of it til now. This
avoids some conditionals and having to set/unset the worker pool
ivar as the daemon is started/stopped.

As part of this change, qs now also provides a `Worker` mixin which
as mentioned before, contains the logic for processing a queue
item. It also contains the on-available and on-error logic that
was previously buried in the `Daemon` class. This mixin is
required for any worker class that is configured on a daemon. The
worker mixin also protects itself from its included hook being run
multiple times to avoid on-error and on-available callbacks being
added multiple times.

This also includes a number of small changes related to using the
new dat-worker-pool:

* Min and max number of workers are no longer configurable because
  dat-worker-pool no longer supports a min or max. A constant
  number of workers is all that can be configured. It now defaults
  to 4 workers (its previous max value).
* Changed the work loop organization to try and make it more
  readable and consistent with dat-tcp/dat-worker-pool.
* Updated styles and conventions to our latest standards
  throughout.

@kellyredding - Ready for review. The benchmarks are slower but I'm pretty sure its just my machine's current state, I'm getting the same speeds on master currently. I'll try to get a better benchmark or just reset the current ones in master with a hotfix. I'm not sure if I've changed OS version since running the benchmarks last.