### PR TITLE
Pass logger to dat-worker-pool when in debug mode

### DIFF
--- a/lib/qs/daemon_data.rb
+++ b/lib/qs/daemon_data.rb
@@ -7,26 +7,29 @@ module Qs
     # options one time here and memoize their values. This way, we don't pay the
     # NsOptions overhead when reading them while handling a message.
 
-    attr_reader :name, :process_label
-    attr_reader :pid_file
-    attr_reader :worker_class, :worker_params
-    attr_reader :num_workers
-    attr_reader :logger, :verbose_logging
+    attr_reader :name, :process_label, :pid_file
+    attr_reader :worker_class, :worker_params, :num_workers
+    attr_reader :debug, :logger, :dwp_logger, :verbose_logging
     attr_reader :shutdown_timeout
-    attr_reader :error_procs
-    attr_reader :queue_redis_keys, :routes
+    attr_reader :error_procs, :queue_redis_keys, :routes
 
     def initialize(args = nil)
       args ||= {}
-      @name             = args[:name]
-      @process_label    = !(v = ENV['QS_PROCESS_LABEL'].to_s).empty? ? v : args[:name]
-      @pid_file         = args[:pid_file]
-      @worker_class     = args[:worker_class]
-      @worker_params    = args[:worker_params] || {}
-      @num_workers      = args[:num_workers]
-      @logger           = args[:logger]
-      @verbose_logging  = !!args[:verbose_logging]
+      @name          = args[:name]
+      @process_label = !(v = ENV['QS_PROCESS_LABEL'].to_s).empty? ? v : args[:name]
+      @pid_file      = args[:pid_file]
+
+      @worker_class  = args[:worker_class]
+      @worker_params = args[:worker_params] || {}
+      @num_workers   = args[:num_workers]
+
+      @debug           = !ENV['QS_DEBUG'].to_s.empty?
+      @logger          = args[:logger]
+      @dwp_logger      = @logger if @debug
+      @verbose_logging = !!args[:verbose_logging]
+
       @shutdown_timeout = args[:shutdown_timeout]
+
       @error_procs      = args[:error_procs] || []
       @queue_redis_keys = args[:queue_redis_keys] || []
       @routes           = build_routes(args[:routes] || [])

--- a/lib/qs/payload_handler.rb
+++ b/lib/qs/payload_handler.rb
@@ -26,7 +26,6 @@ module Qs
       benchmark = Benchmark.measure{ run!(@daemon_data, @queue_item) }
       @queue_item.time_taken = RoundedTime.new(benchmark.real)
       log_complete(@queue_item)
-      raise_if_debugging!(@queue_item.exception)
     end
 
     private
@@ -67,10 +66,6 @@ module Qs
       log_exception(queue_item.exception)
     end
 
-    def raise_if_debugging!(exception)
-      raise exception if exception && ENV['QS_DEBUG']
-    end
-
     def log_received
       log_verbose "===== Received message ====="
     end
@@ -99,9 +94,8 @@ module Qs
     end
 
     def log_exception(exception)
-      backtrace = (exception.backtrace || []).join("\n")
-      message = "#{exception.class}: #{exception.message}\n#{backtrace}"
-      log_verbose(message, :error)
+      log_verbose("#{exception.class}: #{exception.message}", :error)
+      (exception.backtrace || []).each{ |l| log_verbose(l, :error) }
     end
 
     def log_verbose(message, level = :info)

--- a/test/unit/daemon_tests.rb
+++ b/test/unit/daemon_tests.rb
@@ -227,6 +227,7 @@ module Qs::Daemon
 
       assert_not_nil @wp_spy
       assert_equal data.worker_class, @wp_spy.worker_class
+      assert_equal data.dwp_logger,   @wp_spy.logger
       assert_equal data.num_workers,  @wp_spy.num_workers
       exp = data.worker_params.merge({
         :qs_daemon_data      => data,

--- a/test/unit/payload_handler_tests.rb
+++ b/test/unit/payload_handler_tests.rb
@@ -142,21 +142,6 @@ class Qs::PayloadHandler
 
   end
 
-  class RunWithExceptionWhileDebuggingTests < RunWithExceptionSetupTests
-    desc "and run with an exception"
-    setup do
-      ENV['QS_DEBUG'] = '1'
-    end
-    teardown do
-      ENV.delete('QS_DEBUG')
-    end
-
-    should "raise the exception" do
-      assert_raises(@route_exception.class){ @payload_handler.run }
-    end
-
-  end
-
   class LoggingJobSetupTests < InitSetupTests
     desc "and run with a job queue item"
     setup do
@@ -210,9 +195,11 @@ class Qs::PayloadHandler
     should "log the error" do
       logger_spy = subject.logger
       exception = @queue_item.exception
-      backtrace = exception.backtrace.join("\n")
-      exp = "[Qs] #{exception.class}: #{exception.message}\n#{backtrace}"
+      exp = "[Qs] #{exception.class}: #{exception.message}"
       assert_equal exp, logger_spy.verbose.error_logged.first
+      exception.backtrace.each do |l|
+        assert_includes "[Qs] #{l}", logger_spy.verbose.error_logged
+      end
 
       exp = JobSummaryLine.new(@job, {
         'time'    => @queue_item.time_taken,
@@ -282,9 +269,11 @@ class Qs::PayloadHandler
     should "log the error" do
       logger_spy = subject.logger
       exception = @queue_item.exception
-      backtrace = exception.backtrace.join("\n")
-      exp = "[Qs] #{exception.class}: #{exception.message}\n#{backtrace}"
+      exp = "[Qs] #{exception.class}: #{exception.message}"
       assert_equal exp, logger_spy.verbose.error_logged.first
+      exception.backtrace.each do |l|
+        assert_includes "[Qs] #{l}", logger_spy.verbose.error_logged
+      end
 
       exp = EventSummaryLine.new(@event, {
         'time'    => @queue_item.time_taken,
@@ -320,9 +309,11 @@ class Qs::PayloadHandler
 
       logger_spy = subject.logger
       exception = @queue_item.exception
-      backtrace = exception.backtrace.join("\n")
-      exp = "[Qs] #{exception.class}: #{exception.message}\n#{backtrace}"
+      exp = "[Qs] #{exception.class}: #{exception.message}"
       assert_equal exp, logger_spy.verbose.error_logged.first
+      exception.backtrace.each do |l|
+        assert_includes "[Qs] #{l}", logger_spy.verbose.error_logged
+      end
 
       exp = UnknownSummaryLine.new({
         'time'    => @queue_item.time_taken,


### PR DESCRIPTION
This updates qs debug mode and to pass its logger to
dat-worker-pool when its in debug mode. This allows extra logging
provided by dat-worker-pool. This also removes duplicate logging
that is now handled by dat-worker-pool and the payload handler
raising an exception if in debug mode. All of this is to formalize
the debug mode of qs and take advantage of dat-worker-pools
logging.

The daemon data now has a `debug` flag that is set by the env var
`QS_DEBUG`. When this is set, the qs logger will be passed to
dat-worker-pool. This shouldn't be set in a live environment
because dat-worker-pool does a lot of extra logging that will slow
down qs processing.

This also removes the payload handler raising an exception if the
`QS_DEBUG` flag is set. This is a development feature that was
used when initially developing qs logic. It was never intended to
be a feature outside of the qs repo and test suite. This removes
it so its no longer tied to the `QS_DEBUG` env var. If we need it
again when updating qs we can figure a way to add the feature back
so that it is only part of the test suite.

@kellyredding - Ready for review.