### PR TITLE
Use much-plugin for daemon, worker and handlers

### DIFF
--- a/lib/qs/daemon.rb
+++ b/lib/qs/daemon.rb
@@ -1,4 +1,5 @@
 require 'dat-worker-pool'
+require 'much-plugin'
 require 'ns-options'
 require 'pathname'
 require 'system_timer'
@@ -13,16 +14,15 @@ require 'qs/worker'
 module Qs
 
   module Daemon
+    include MuchPlugin
 
     InvalidError = Class.new(ArgumentError)
 
     SIGNAL = '.'.freeze
 
-    def self.included(klass)
-      klass.class_eval do
-        extend ClassMethods
-        include InstanceMethods
-      end
+    plugin_included do
+      extend ClassMethods
+      include InstanceMethods
     end
 
     module InstanceMethods

--- a/lib/qs/event_handler.rb
+++ b/lib/qs/event_handler.rb
@@ -1,14 +1,14 @@
+require 'much-plugin'
 require 'qs/message_handler'
 
 module Qs
 
   module EventHandler
+    include MuchPlugin
 
-    def self.included(klass)
-      klass.class_eval do
-        include Qs::MessageHandler
-        include InstanceMethods
-      end
+    plugin_included do
+      include Qs::MessageHandler
+      include InstanceMethods
     end
 
     module InstanceMethods

--- a/lib/qs/job_handler.rb
+++ b/lib/qs/job_handler.rb
@@ -1,14 +1,14 @@
+require 'much-plugin'
 require 'qs/message_handler'
 
 module Qs
 
   module JobHandler
+    include MuchPlugin
 
-    def self.included(klass)
-      klass.class_eval do
-        include Qs::MessageHandler
-        include InstanceMethods
-      end
+    plugin_included do
+      include Qs::MessageHandler
+      include InstanceMethods
     end
 
     module InstanceMethods

--- a/lib/qs/message_handler.rb
+++ b/lib/qs/message_handler.rb
@@ -1,12 +1,13 @@
+require 'much-plugin'
+
 module Qs
 
   module MessageHandler
+    include MuchPlugin
 
-    def self.included(klass)
-      klass.class_eval do
-        extend ClassMethods
-        include InstanceMethods
-      end
+    plugin_included do
+      extend ClassMethods
+      include InstanceMethods
     end
 
     module InstanceMethods

--- a/qs.gemspec
+++ b/qs.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency("dat-worker-pool", ["~> 0.5"])
   gem.add_dependency("hella-redis",     ["~> 0.3"])
+  gem.add_dependency("much-plugin",     ["~> 0.1"])
   gem.add_dependency("ns-options",      ["~> 1.1"])
   gem.add_dependency("SystemTimer",     ["~> 1.2"])
 

--- a/test/unit/daemon_tests.rb
+++ b/test/unit/daemon_tests.rb
@@ -2,6 +2,7 @@ require 'assert'
 require 'qs/daemon'
 
 require 'dat-worker-pool/worker_pool_spy'
+require 'much-plugin'
 require 'ns-options/assert_macros'
 require 'thread'
 require 'qs/client'
@@ -25,6 +26,10 @@ module Qs::Daemon
     should have_imeths :verbose_logging, :logger
     should have_imeths :shutdown_timeout
     should have_imeths :init, :error, :queue
+
+    should "use much-plugin" do
+      assert_includes MuchPlugin, Qs::Daemon
+    end
 
     should "know its configuration" do
       config = subject.configuration
@@ -143,7 +148,7 @@ module Qs::Daemon
       @worker_available = WorkerAvailable.new
       Assert.stub(WorkerAvailable, :new){ @worker_available }
 
-      @wp_spy             = nil
+      @wp_spy              = nil
       @wp_worker_available = true
       Assert.stub(DatWorkerPool, :new) do |*args|
         @wp_spy = DatWorkerPool::WorkerPoolSpy.new(*args)

--- a/test/unit/event_handler_tests.rb
+++ b/test/unit/event_handler_tests.rb
@@ -1,6 +1,7 @@
 require 'assert'
 require 'qs/event_handler'
 
+require 'much-plugin'
 require 'qs'
 require 'qs/message_handler'
 require 'qs/test_runner'
@@ -19,6 +20,10 @@ module Qs::EventHandler
       Qs.reset!
     end
     subject{ @handler_class }
+
+    should "use much-plugin" do
+      assert_includes MuchPlugin, Qs::Worker
+    end
 
     should "be a message handler" do
       assert_includes Qs::MessageHandler, subject

--- a/test/unit/job_handler_tests.rb
+++ b/test/unit/job_handler_tests.rb
@@ -1,6 +1,7 @@
 require 'assert'
 require 'qs/job_handler'
 
+require 'much-plugin'
 require 'qs'
 require 'qs/message_handler'
 require 'qs/test_runner'
@@ -19,6 +20,10 @@ module Qs::JobHandler
       Qs.reset!
     end
     subject{ @handler_class }
+
+    should "use much-plugin" do
+      assert_includes MuchPlugin, Qs::Worker
+    end
 
     should "be a message handler" do
       assert_includes Qs::MessageHandler, subject

--- a/test/unit/message_handler_tests.rb
+++ b/test/unit/message_handler_tests.rb
@@ -1,6 +1,7 @@
 require 'assert'
 require 'qs/message_handler'
 
+require 'much-plugin'
 require 'test/support/message_handler'
 
 module Qs::MessageHandler
@@ -28,6 +29,10 @@ module Qs::MessageHandler
     should have_imeths :prepend_before, :prepend_after
     should have_imeths :prepend_before_init, :prepend_after_init
     should have_imeths :prepend_before_run,  :prepend_after_run
+
+    should "use much-plugin" do
+      assert_includes MuchPlugin, Qs::Worker
+    end
 
     should "allow reading/writing its timeout" do
       assert_nil subject.timeout

--- a/test/unit/worker_tests.rb
+++ b/test/unit/worker_tests.rb
@@ -2,6 +2,7 @@ require 'assert'
 require 'qs/worker'
 
 require 'dat-worker-pool/worker'
+require 'much-plugin'
 require 'qs/daemon'
 require 'qs/daemon_data'
 require 'qs/logger'
@@ -18,6 +19,10 @@ module Qs::Worker
       @worker_class = Class.new{ include Qs::Worker }
     end
     subject{ @worker_class }
+
+    should "use much-plugin" do
+      assert_includes MuchPlugin, Qs::Worker
+    end
 
     should "be a dat-worker-pool worker" do
       assert_includes DatWorkerPool::Worker, subject


### PR DESCRIPTION
This updates the daemon, worker and handler mixins to use
much-plugin. This ensures the mixin logic is only included once and
ensures the worker callbacks don't get added multiple times.

@kellyredding - Ready for review.