### PR TITLE
add `queues` method on Daemons

### DIFF
--- a/lib/qs/daemon.rb
+++ b/lib/qs/daemon.rb
@@ -196,12 +196,12 @@ module Qs
       end
 
       def worker_class(new_worker_class = nil)
-        self.configuration.worker_class = new_worker_class if new_worker_class
+        self.configuration.worker_class = new_worker_class if !new_worker_class.nil?
         self.configuration.worker_class
       end
 
-      def worker_params(new_worker_params = nil )
-        self.configuration.worker_params = new_worker_params if new_worker_params
+      def worker_params(new_worker_params = nil)
+        self.configuration.worker_params = new_worker_params if !new_worker_params.nil?
         self.configuration.worker_params
       end
 
@@ -232,6 +232,10 @@ module Qs
 
       def queue(queue)
         self.configuration.queues << queue
+      end
+
+      def queues
+        self.configuration.queues
       end
 
     end

--- a/test/unit/daemon_tests.rb
+++ b/test/unit/daemon_tests.rb
@@ -25,7 +25,7 @@ module Qs::Daemon
     should have_imeths :num_workers, :workers
     should have_imeths :verbose_logging, :logger
     should have_imeths :shutdown_timeout
-    should have_imeths :init, :error, :queue
+    should have_imeths :init, :error, :queue, :queues
 
     should "use much-plugin" do
       assert_includes MuchPlugin, Qs::Daemon
@@ -117,6 +117,12 @@ module Qs::Daemon
       new_queue = Factory.string
       subject.queue(new_queue)
       assert_includes new_queue, subject.configuration.queues
+    end
+
+    should "allow reading its configuration queues" do
+      new_queue = Factory.string
+      subject.queue(new_queue)
+      assert_equal [new_queue], subject.queues
     end
 
   end


### PR DESCRIPTION
Use this to lookup the queues configured on a daemon.  I want to
use this in some tests to ensure a daemon is listening on the queues
it is supposed to be.

This probably should have been there from the beginning as you can
read other configuration items but was missed.

@jcredding ready for review.