### PR TITLE
remove ns-options server config dependency

### DIFF
--- a/lib/qs/config_file.rb
+++ b/lib/qs/config_file.rb
@@ -35,7 +35,7 @@ module Qs
       full_path_with_sanford
     end
 
-    # This evaluates the file and creates a proc using it's contents. This is
+    # This evaluates the file and creates a proc using its contents. This is
     # a trick borrowed from Rack. It is essentially converting a file into a
     # proc and then instance eval'ing it. This has a couple benefits:
     # * The obvious benefit is the file is evaluated in the context of this

--- a/lib/qs/daemon_data.rb
+++ b/lib/qs/daemon_data.rb
@@ -2,37 +2,38 @@ module Qs
 
   class DaemonData
 
-    # The daemon uses this to "compile" its configuration for speed. NsOptions
-    # is relatively slow everytime an option is read. To avoid this, we read the
-    # options one time here and memoize their values. This way, we don't pay the
-    # NsOptions overhead when reading them while handling a message.
+    # The daemon uses this to "compile" the common configuration data used
+    # by the daemon instances, error handlers and routes. The goal here is
+    # to provide these with a simplified interface with the minimal data needed
+    # and to decouple the configuration from each thing that needs its data.
 
-    attr_reader :name, :process_label, :pid_file
+    attr_reader :name, :pid_file, :shutdown_timeout
     attr_reader :worker_class, :worker_params, :num_workers
-    attr_reader :debug, :logger, :dwp_logger, :verbose_logging
-    attr_reader :shutdown_timeout
-    attr_reader :error_procs, :queue_redis_keys, :routes
+    attr_reader :error_procs, :logger, :queue_redis_keys
+    attr_reader :verbose_logging
+    attr_reader :debug, :dwp_logger, :routes, :process_label
 
     def initialize(args = nil)
       args ||= {}
-      @name          = args[:name]
-      @process_label = !(v = ENV['QS_PROCESS_LABEL'].to_s).empty? ? v : args[:name]
-      @pid_file      = args[:pid_file]
-
-      @worker_class  = args[:worker_class]
-      @worker_params = args[:worker_params] || {}
-      @num_workers   = args[:num_workers]
-
-      @debug           = !ENV['QS_DEBUG'].to_s.empty?
-      @logger          = args[:logger]
-      @dwp_logger      = @logger if @debug
-      @verbose_logging = !!args[:verbose_logging]
+      @name     = args[:name]
+      @pid_file = args[:pid_file]
 
       @shutdown_timeout = args[:shutdown_timeout]
 
+      @worker_class     = args[:worker_class]
+      @worker_params    = args[:worker_params] || {}
+      @num_workers      = args[:num_workers]
       @error_procs      = args[:error_procs] || []
-      @queue_redis_keys = args[:queue_redis_keys] || []
-      @routes           = build_routes(args[:routes] || [])
+      @logger           = args[:logger]
+      @queue_redis_keys = (args[:queues] || []).map(&:redis_key)
+
+      @verbose_logging = !!args[:verbose_logging]
+
+      @debug      = !ENV['QS_DEBUG'].to_s.empty?
+      @dwp_logger = @logger if @debug
+      @routes     = build_routes(args[:routes] || [])
+
+      @process_label = !(v = ENV['QS_PROCESS_LABEL'].to_s).empty? ? v : @name
     end
 
     def route_for(route_id)

--- a/qs.gemspec
+++ b/qs.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.15.1"])
+  gem.add_development_dependency("assert", ["~> 2.16.1"])
   gem.add_development_dependency("scmd",   ["~> 3.0.1"])
 
   gem.add_dependency("dat-worker-pool", ["~> 0.6.0"])

--- a/test/support/config.qs
+++ b/test/support/config.qs
@@ -1,7 +1,14 @@
-require 'test/support/app_daemon'
+require 'test/support/app_queue'
 
 if !defined?(TestConstant)
   TestConstant = Class.new
 end
 
-run AppDaemon.new
+class ConfigFileTestDaemon
+  include Qs::Daemon
+
+  name  'qs-config-file-test'
+  queue AppQueue
+end
+
+run ConfigFileTestDaemon.new

--- a/test/system/queue_tests.rb
+++ b/test/system/queue_tests.rb
@@ -1,7 +1,7 @@
 require 'assert'
 require 'qs'
 
-require 'test/support/app_daemon'
+require 'test/support/app_queue'
 
 class Qs::Queue
 

--- a/test/unit/config_file_tests.rb
+++ b/test/unit/config_file_tests.rb
@@ -15,7 +15,7 @@ class Qs::ConfigFile
     should have_imeths :run
 
     should "know its daemon" do
-      assert_instance_of AppDaemon, subject.daemon
+      assert_instance_of ConfigFileTestDaemon, subject.daemon
     end
 
     should "define constants in the file at the top-level binding" do
@@ -35,7 +35,7 @@ class Qs::ConfigFile
       assert_nothing_raised do
         config_file = Qs::ConfigFile.new(file_path)
       end
-      assert_instance_of AppDaemon, config_file.daemon
+      assert_instance_of ConfigFileTestDaemon, config_file.daemon
     end
 
     should "raise no config file error when the file doesn't exist" do

--- a/test/unit/daemon_data_tests.rb
+++ b/test/unit/daemon_data_tests.rb
@@ -13,23 +13,27 @@ class Qs::DaemonData
       ENV['QS_PROCESS_LABEL']    = Factory.string
 
       @current_env_debug = ENV['QS_DEBUG']
-      ENV['QS_DEBUG']    = Factory.string
+      ENV.delete('QS_DEBUG')
 
-      @routes = (0..Factory.integer(3)).map do
+      @queues = Factory.integer(3).times.map do
+        Qs::Queue.new{ name Factory.string }
+      end
+
+      @routes = Factory.integer(3).times.map do
         Qs::Route.new(Factory.string, TestHandler.to_s).tap(&:validate!)
       end
 
       @config_hash = {
         :name             => Factory.string,
         :pid_file         => Factory.file_path,
+        :shutdown_timeout => Factory.integer,
         :worker_class     => Class.new,
         :worker_params    => { Factory.string => Factory.string },
         :num_workers      => Factory.integer,
+        :error_procs      => Factory.integer(3).times.map{ proc{} },
         :logger           => Factory.string,
+        :queues           => @queues,
         :verbose_logging  => Factory.boolean,
-        :shutdown_timeout => Factory.integer,
-        :error_procs      => [ proc{ Factory.string } ],
-        :queue_redis_keys => Factory.integer(3).times.map{ Factory.string },
         :routes           => @routes
       }
       @daemon_data = Qs::DaemonData.new(@config_hash)
@@ -40,31 +44,40 @@ class Qs::DaemonData
     end
     subject{ @daemon_data }
 
-    should have_readers :name, :process_label, :pid_file
+    should have_readers :name, :pid_file, :shutdown_timeout
     should have_readers :worker_class, :worker_params, :num_workers
-    should have_readers :debug, :logger, :dwp_logger, :verbose_logging
-    should have_readers :shutdown_timeout
-    should have_readers :error_procs, :queue_redis_keys, :routes
+    should have_readers :error_procs, :logger, :queue_redis_keys
+    should have_readers :verbose_logging
+    should have_readers :debug, :dwp_logger, :routes, :process_label
     should have_imeths :route_for
 
-    should "know its attributes" do
+    should "know its attrs" do
       h = @config_hash
-      assert_equal h[:name],             subject.name
-      assert_equal h[:pid_file],         subject.pid_file
-      assert_equal h[:worker_class],     subject.worker_class
-      assert_equal h[:worker_params],    subject.worker_params
-      assert_equal h[:num_workers],      subject.num_workers
-      assert_equal h[:logger],           subject.logger
-      assert_equal h[:verbose_logging],  subject.verbose_logging
+      assert_equal h[:name],     subject.name
+      assert_equal h[:pid_file], subject.pid_file
+
       assert_equal h[:shutdown_timeout], subject.shutdown_timeout
-      assert_equal h[:error_procs],      subject.error_procs
-      assert_equal h[:queue_redis_keys], subject.queue_redis_keys
+
+      assert_equal h[:worker_class],  subject.worker_class
+      assert_equal h[:worker_params], subject.worker_params
+      assert_equal h[:num_workers],   subject.num_workers
+      assert_equal h[:error_procs],   subject.error_procs
+      assert_equal h[:logger],        subject.logger
+
+      exp = @queues.map(&:redis_key)
+      assert_equal exp, subject.queue_redis_keys
+
+      assert_equal h[:verbose_logging], subject.verbose_logging
+
+      assert_false subject.debug
+      assert_nil   subject.dwp_logger
+
+      exp = @routes.inject({}){ |h, r| h.merge(r.id => r) }
+      assert_equal exp, subject.routes
     end
 
-    should "use process label env var if set" do
-      ENV['QS_PROCESS_LABEL'] = Factory.string
-      daemon_data = Qs::DaemonData.new(@config_hash)
-      assert_equal ENV['QS_PROCESS_LABEL'], daemon_data.process_label
+    should "know its process label" do
+      assert_equal ENV['QS_PROCESS_LABEL'], subject.process_label
 
       ENV['QS_PROCESS_LABEL'] = ""
       daemon_data = Qs::DaemonData.new(@config_hash)
@@ -75,32 +88,16 @@ class Qs::DaemonData
       assert_equal @config_hash[:name], daemon_data.process_label
     end
 
-    should "use debug env var if set" do
+    should "use the debug env var if set" do
       ENV['QS_DEBUG'] = Factory.string
       daemon_data = Qs::DaemonData.new(@config_hash)
       assert_true daemon_data.debug
-      assert_equal @config_hash[:logger], daemon_data.dwp_logger
-
-      ENV['QS_DEBUG'] = ""
-      daemon_data = Qs::DaemonData.new(@config_hash)
-      assert_false daemon_data.debug
-      assert_nil daemon_data.dwp_logger
-
-      ENV.delete('QS_DEBUG')
-      daemon_data = Qs::DaemonData.new(@config_hash)
-      assert_false daemon_data.debug
-      assert_nil daemon_data.dwp_logger
+      assert_equal daemon_data.logger, daemon_data.dwp_logger
     end
 
-    should "build a routes lookup hash" do
-      expected = @routes.inject({}){ |h, r| h.merge(r.id => r) }
-      assert_equal expected, subject.routes
-    end
-
-    should "allow looking up a route using `route_for`" do
+    should "look up a route using `route_for`" do
       exp_route = @routes.choice
-      route = subject.route_for(exp_route.id)
-      assert_equal exp_route, route
+      assert_equal exp_route, subject.route_for(exp_route.id)
     end
 
     should "raise a not found error using `route_for` with an invalid name" do
@@ -109,18 +106,26 @@ class Qs::DaemonData
       end
     end
 
-    should "default its attributes when they aren't provided" do
+    should "default its attrs when they aren't provided" do
       daemon_data = Qs::DaemonData.new
       assert_nil daemon_data.name
       assert_nil daemon_data.pid_file
+      assert_nil daemon_data.shutdown_timeout
+
       assert_nil daemon_data.worker_class
       assert_equal({}, daemon_data.worker_params)
       assert_nil daemon_data.num_workers
-      assert_nil daemon_data.logger
-      assert_false daemon_data.verbose_logging
-      assert_nil daemon_data.shutdown_timeout
+
       assert_equal [], daemon_data.error_procs
+
+      assert_nil daemon_data.logger
       assert_equal [], daemon_data.queue_redis_keys
+
+      assert_false daemon_data.verbose_logging
+
+      assert_false daemon_data.debug
+      assert_nil daemon_data.dwp_logger
+
       assert_equal({}, daemon_data.routes)
     end
 

--- a/test/unit/message_handler_tests.rb
+++ b/test/unit/message_handler_tests.rb
@@ -211,7 +211,7 @@ module Qs::MessageHandler
       @handler.qs_run
     end
 
-    should "call `run!` and it's callbacks" do
+    should "call `run!` and its callbacks" do
       assert_equal 6,  subject.first_before_run_call_order
       assert_equal 7,  subject.second_before_run_call_order
       assert_equal 8,  subject.run_call_order


### PR DESCRIPTION
We are moving away from using ns-options as a dependency b/c it
has performance issues when accessing options and on top of that
its API hasn't proven to be especially useful over a struct-like
class.

This removes ns-options from the daemon config and reworks the
daemon, its config and the daemon data to support the non
ns-options config implementation. The config is now a simple
struct-like class with a bunch of accessors for its attrs.  The
daemon class methods now implement the ns-options-like DSL api
for each of their attrs for backwards compatibility.

Note: I had to rework the system tests and their support files a
bit to get things passing.  This all stems from the daemon system
tests needing to reset daemon configs for each run which isn't
possible now that ns-options is not in play.  I switched to building
a new daemon class on the start of each test run.  This ensures
that the state is the same for each run and also removes the usage
of a global `AppDaemon`.  In addition, this revealed coupling between
tests related to some global support objects.  I kept the global
`AppQueue` as it is used between the queue/daemon system tests but
put it in its own support file.  I switched the support config.qs to
build its own daemon and no longer rely on a global support `AppDaemon`.
Finally, the dispatcher daemon is only needed for the daemon system
tests so I moved its implementation into the tests file.

In addition, I did a number of smaller changes/cleanups, including
some things that aren't backwards compatible:

* switched to calling the config "config" (more succinct than prev
  with no loss of clarity).
* you can no longer set config values to procs (for lazy eval'ing).
  I chose to not keep this behavior.
* I dropped the `to_hash` logic and switched to just manually
  building the daemon data.  I'm just trying to simplify the API
  here and blindly using the config's hash kinda hides what values
  are being set.
* I reworked the order of config/daemon/daemon-data settings to
  try and get everything to match.  This is just to be consistent
  and help keep things organized/readable.  I tried to follow the
  order Deas/Sanford uses as much as possible.
* I did a bunch of test cleanups to not only test the new logic
  but use modern conventions like Factory values and also test
  things more thoroughly.
* updated the assert dependency to get access to the latest stuff.

Overall there are some backwards incompatible changes but the basic
behavior isn't changing.  Most of the diff is just reordering things
and reworking to remove ns-options logic where needed.

See redding/sanford#173 and redding/sanford#174 for reference.  Most of the changes here are the result of similar work in Sanford.  The goal is to keep the implementation in sync as much as possible.

@jcredding ready for review.  I still need to remove ns-options from the client which I'll do in a coming PR.