### PR TITLE
remove `dispatcher` namespace from main Qs::Config

### DIFF
--- a/bench/setup.rb
+++ b/bench/setup.rb
@@ -16,7 +16,7 @@ else
   File.open('/dev/null', 'w')
 end
 
-Qs.config.dispatcher.queue_name = 'bench-dispatcher'
+Qs.config.dispatcher_queue_name = 'bench-dispatcher'
 Qs.config.event_publisher = 'Bench Script'
 Qs.init
 

--- a/lib/qs.rb
+++ b/lib/qs.rb
@@ -23,9 +23,9 @@ module Qs
 
     @dispatcher_queue ||= DispatcherQueue.new({
       :queue_class            => self.config.dispatcher_queue_class,
-      :queue_name             => self.config.dispatcher.queue_name,
-      :job_name               => self.config.dispatcher.job_name,
-      :job_handler_class_name => self.config.dispatcher.job_handler_class_name
+      :queue_name             => self.config.dispatcher_queue_name,
+      :job_name               => self.config.dispatcher_job_name,
+      :job_handler_class_name => self.config.dispatcher_job_handler_class_name
     })
 
     @encoder ||= self.config.encoder
@@ -98,7 +98,7 @@ module Qs
   end
 
   def self.dispatcher_job_name
-    self.config.dispatcher.job_name
+    self.config.dispatcher_job_name
   end
 
   def self.event_publisher
@@ -119,12 +119,6 @@ module Qs
 
     option :event_publisher, String
 
-    namespace :dispatcher do
-      option :queue_name,             String, :default => 'dispatcher'
-      option :job_name,               String, :default => 'run_dispatch_job'
-      option :job_handler_class_name, String, :default => DispatcherQueue::RunDispatchJob.to_s
-    end
-
     namespace :redis do
       option :ip,   :default => '127.0.0.1'
       option :port, :default => 6379
@@ -138,18 +132,30 @@ module Qs
       option :size,     Integer, :default => 4
     end
 
-    attr_accessor :dispatcher_queue_class
+    DEFAULT_DISPATCHER_QUEUE_CLASS            = Queue
+    DEFAULT_DISPATCHER_QUEUE_NAME             = 'dispatcher'.freeze
+    DEFAULT_DISPATCHER_JOB_NAME               = 'run_dispatch_job'.freeze
+    DEFAULT_DISPATCHER_JOB_HANDLER_CLASS_NAME = DispatcherQueue::RunDispatchJob.to_s.freeze
+
+    attr_accessor :dispatcher_queue_class, :dispatcher_queue_name
+    attr_accessor :dispatcher_job_name, :dispatcher_job_handler_class_name
 
     def initialize
-      self.dispatcher_queue_class = Queue
+      @dispatcher_queue_class            = DEFAULT_DISPATCHER_QUEUE_CLASS
+      @dispatcher_queue_name             = DEFAULT_DISPATCHER_QUEUE_NAME
+      @dispatcher_job_name               = DEFAULT_DISPATCHER_JOB_NAME
+      @dispatcher_job_handler_class_name = DEFAULT_DISPATCHER_JOB_HANDLER_CLASS_NAME
     end
+
   end
 
   module RedisUrl
+
     def self.new(ip, port, db)
       return if ip.to_s.empty? || port.to_s.empty? || db.to_s.empty?
       "redis://#{ip}:#{port}/#{db}"
     end
+
   end
 
 end

--- a/test/system/daemon_tests.rb
+++ b/test/system/daemon_tests.rb
@@ -11,7 +11,7 @@ module Qs::Daemon
       Qs.reset!
       @qs_test_mode = ENV['QS_TEST_MODE']
       ENV['QS_TEST_MODE'] = nil
-      Qs.config.dispatcher.queue_name = 'qs-app-dispatcher'
+      Qs.config.dispatcher_queue_name = 'qs-app-dispatcher'
       Qs.config.event_publisher       = 'Daemon System Tests'
       Qs.init
       AppQueue.sync_subscriptions
@@ -314,8 +314,8 @@ module Qs::Daemon
     queue Qs::DispatcherQueue.new({
       :queue_class            => Qs.config.dispatcher_queue_class,
       :queue_name             => 'qs-app-dispatcher',
-      :job_name               => Qs.config.dispatcher.job_name,
-      :job_handler_class_name => Qs.config.dispatcher.job_handler_class_name
+      :job_name               => Qs.config.dispatcher_job_name,
+      :job_handler_class_name => Qs.config.dispatcher_job_handler_class_name
     })
   end
 

--- a/test/unit/cli_tests.rb
+++ b/test/unit/cli_tests.rb
@@ -123,8 +123,8 @@ class Qs::CLI
     end
 
     should "output the error with the help" do
-      expected = "#{@command.inspect} is not a valid command"
-      assert_includes expected, @kernel_spy.output
+      exp = "#{@command.inspect} is not a valid command"
+      assert_includes exp,         @kernel_spy.output
       assert_includes "Usage: qs", @kernel_spy.output
     end
 

--- a/test/unit/queue_tests.rb
+++ b/test/unit/queue_tests.rb
@@ -162,11 +162,11 @@ class Qs::Queue
 
     should "know its custom inspect" do
       reference = '0x0%x' % (subject.object_id << 1)
-      expected = "#<#{subject.class}:#{reference} " \
-                   "@name=#{subject.name.inspect} " \
-                   "@job_handler_ns=#{subject.job_handler_ns.inspect} " \
-                   "@event_handler_ns=#{subject.event_handler_ns.inspect}>"
-      assert_equal expected, subject.inspect
+      exp = "#<#{subject.class}:#{reference} " \
+            "@name=#{subject.name.inspect} " \
+            "@job_handler_ns=#{subject.job_handler_ns.inspect} " \
+            "@event_handler_ns=#{subject.event_handler_ns.inspect}>"
+      assert_equal exp, subject.inspect
     end
 
     should "require a name when initialized" do


### PR DESCRIPTION
This is part of a larger effort to remove ns-optioins as a
dependency of Qs and rework the Config as a general struct object.
We are moving away from using ns-options as a dependency b/c it
has performance issues when accessing options and on top of that
its API hasn't proven to be especially useful over a struct-like
class.

This removes the `dispatcher` namespace and switches its attrs to
be plain accessors on the Config.  I'm just doing this namespace
here to keep the diff from getting too big.  In future efforts
I'll remove the `redis` namespace and remove ns-options from the
Config altogether.

Note: this includes a number of test style cleanups to get up to
our latest conventions.  I noticed these while reworking the
config tests.

@jcredding ready for review.