### PR TITLE
remove `redis` namespace from main Qs::Config

### DIFF
--- a/lib/qs/client.rb
+++ b/lib/qs/client.rb
@@ -25,10 +25,10 @@ module Qs
 
     module InstanceMethods
 
-      attr_reader :redis_config, :redis
+      attr_reader :redis_connect_hash, :redis
 
-      def initialize(redis_config)
-        @redis_config = redis_config
+      def initialize(redis_connect_hash)
+        @redis_connect_hash = redis_connect_hash
       end
 
       def enqueue(queue, job_name, job_params = nil)
@@ -119,7 +119,7 @@ module Qs
 
     def initialize(*args)
       super
-      @redis = HellaRedis::Connection.new(self.redis_config)
+      @redis = HellaRedis::Connection.new(self.redis_connect_hash)
     end
 
     def push(queue_name, payload_hash)
@@ -145,7 +145,7 @@ module Qs
     def initialize(*args)
       super
       require 'hella-redis/connection_spy'
-      @redis = HellaRedis::ConnectionSpy.new(self.redis_config)
+      @redis = HellaRedis::ConnectionSpy.new(self.redis_connect_hash)
       @pushed_items = []
     end
 

--- a/lib/qs/daemon.rb
+++ b/lib/qs/daemon.rb
@@ -59,7 +59,7 @@ module Qs
         # set the size of the client to the num workers + 1, this ensures we
         # have 1 connection for fetching work from redis and at least 1
         # connection for each worker to requeue its message when hard-shutdown
-        @client = QsClient.new(Qs.redis_config.merge({
+        @client = QsClient.new(Qs.redis_connect_hash.merge({
           :timeout => 1,
           :size    => self.daemon_data.num_workers + 1
         }))

--- a/test/support/client_spy.rb
+++ b/test/support/client_spy.rb
@@ -3,8 +3,8 @@ require 'qs/client'
 class ClientSpy < Qs::TestClient
   attr_reader :calls
 
-  def initialize(redis_config = nil)
-    super(redis_config || {})
+  def initialize(redis_connect_hash = nil)
+    super(redis_connect_hash || {})
     @calls = []
     @list  = []
     @mutex = Mutex.new

--- a/test/unit/daemon_tests.rb
+++ b/test/unit/daemon_tests.rb
@@ -176,11 +176,11 @@ module Qs::Daemon
 
     should "build a client" do
       assert_not_nil @client_spy
-      exp = Qs.redis_config.merge({
+      exp = Qs.redis_connect_hash.merge({
         :timeout => 1,
         :size    => subject.daemon_data.num_workers + 1
       })
-      assert_equal exp, @client_spy.redis_config
+      assert_equal exp, @client_spy.redis_connect_hash
     end
 
     should "build a dat-worker-pool worker pool" do
@@ -483,11 +483,6 @@ module Qs::Daemon
 
       @config_class = Config
       @config = Config.new
-
-      # @configuration = Configuration.new.tap do |c|
-      #   c.name Factory.string
-      #   c.queues << @queue
-      # end
     end
     subject{ @config }
 


### PR DESCRIPTION
This is part of a larger effort to remove ns-options and rework
the Config as a general struct object. We are moving away from
using ns-options as a dependency b/c it has performance issues
when accessing options and on top of that its API hasn't proven
to be especially useful over a struct-like class.

This removes the `redis` namespace and switches its attrs to
be plain accessors on the Config.  I'm just doing this namespace
here to keep the diff from getting too big.  In a future effort
I'll remove ns-options from the Config altogether.

Note there are a couple backwards incompatible changes I want to
call out:

* I renamed the previous `redis_config` method to `redis_connect_hash`.
  This follows the naming in Ardb's `activerecord_connect_hash`
  and is more explicit about that the object is and what its
  purpose is
* I switched to a validate pattern for setting the redis url.  This
  felt more consistent with how the daemon handles its config.
* Since ns-options is no longer in play, I chose to just set the
  config to `nil` on reset.  I also had to switch to manually
  building the redis connect hash.

Note: this also includes removing some commented out code.  This
was accidentally left in from a previous effort (PR 108).

See #108 for reference.

@jcredding ready for review.  You cool with the backwards incompatible changes?