### PR TITLE
replace SystemTimer with MuchTimeout

### DIFF
--- a/lib/qs.rb
+++ b/lib/qs.rb
@@ -189,4 +189,6 @@ module Qs
 
   end
 
+  TimeoutError = Class.new(RuntimeError)
+
 end

--- a/qs.gemspec
+++ b/qs.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency("dat-worker-pool", ["~> 0.6.0"])
   gem.add_dependency("hella-redis",     ["~> 0.3.0"])
   gem.add_dependency("much-plugin",     ["~> 0.1.0"])
-  gem.add_dependency("SystemTimer",     ["~> 1.2"])
+  gem.add_dependency("much-timeout",    ["~> 0.1.0"])
 
 end


### PR DESCRIPTION
This is part of getting this working in modern ruby versions.
SystemTimer isn't compatible.  This switches to using our new
much-timeout gem for handling timeouts.

There are a couple of minor tweaks related to this change:

* MuchTimeout has an `optional_timeout` method that takes care of
  optionally applying the timeout value.
* this switches to using a custom `Interrupt` exception for the
  timeout.  This exception should never be "swallowed" by user
  code and making it an `Interrupt` helps decrease the odds of
  that compared to it being some `StandardError`.  I also added
  comments describing why it should never be swallowed like
  dat-worker-pool does with its shutdown error.
* this moves the `Qs::TimeoutError` definition into the main Qs
  file/namespace.  This matches how dat-worker-pool organizes
  its main shutdown error

@jcredding ready for review.