### PR TITLE
get test suite passing in modern ruby versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,6 @@ gem 'pry', "~> 0.9.0"
 platform :ruby_18 do
   gem 'json', '~> 1.8'
 end
+
+gem 'dat-worker-pool', :path => "/Users/kelly/projects/redding/gems/dat-worker-pool"
+gem 'hella-redis', :path => "/Users/kelly/projects/redding/gems/hella-redis"

--- a/lib/qs/daemon.rb
+++ b/lib/qs/daemon.rb
@@ -1,6 +1,5 @@
 require 'dat-worker-pool'
 require 'much-plugin'
-require 'system_timer'
 require 'thread'
 require 'qs'
 require 'qs/client'
@@ -14,7 +13,8 @@ module Qs
   module Daemon
     include MuchPlugin
 
-    SIGNAL = '.'.freeze
+    SIGNAL               = '.'.freeze
+    FETCH_ERR_SLEEP_TIME = 1.0.freeze
 
     plugin_included do
       extend ClassMethods
@@ -166,7 +166,7 @@ module Qs
           log "Error occurred while dequeueing", :error
           log "#{exception.class}: #{exception.message}", :error
           (exception.backtrace || []).each{ |l| log(l, :error) }
-          sleep 1
+          sleep FETCH_ERR_SLEEP_TIME
         end
       end
 

--- a/qs.gemspec
+++ b/qs.gemspec
@@ -19,11 +19,11 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_development_dependency("assert", ["~> 2.16.1"])
-  gem.add_development_dependency("scmd",   ["~> 3.0.1"])
+  gem.add_development_dependency("scmd",   ["~> 3.0.2"])
 
   gem.add_dependency("dat-worker-pool", ["~> 0.6.0"])
   gem.add_dependency("hella-redis",     ["~> 0.3.0"])
-  gem.add_dependency("much-plugin",     ["~> 0.1.0"])
+  gem.add_dependency("much-plugin",     ["~> 0.2.0"])
   gem.add_dependency("much-timeout",    ["~> 0.1.0"])
 
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -12,3 +12,14 @@ ROOT_PATH = Pathname.new(File.expand_path('../..', __FILE__))
 require 'test/support/factory'
 
 require 'json' # so the default encoder/decoder procs will work
+
+JOIN_SECONDS = 0.1
+
+# 1.8.7 backfills
+
+# Array#sample
+if !(a = Array.new).respond_to?(:sample) && a.respond_to?(:choice)
+  class Array
+    alias_method :sample, :choice
+  end
+end

--- a/test/support/app_queue.rb
+++ b/test/support/app_queue.rb
@@ -6,9 +6,12 @@ AppQueue = Qs::Queue.new do
   job_handler_ns 'AppHandlers'
 
   job 'basic',   'Basic'
+  job 'basic1',  'Basic'
   job 'error',   'Error'
   job 'timeout', 'Timeout'
   job 'slow',    'Slow'
+  job 'slow1',   'Slow'
+  job 'slow2',   'Slow'
 
   event_handler_ns 'AppHandlers'
 
@@ -39,18 +42,22 @@ module AppHandlers
   class Timeout
     include Qs::JobHandler
 
-    timeout 0.2
+    TIMEOUT_TIME = 0.1
+
+    timeout TIMEOUT_TIME
 
     def run!
-      sleep 2
+      sleep 2*TIMEOUT_TIME
     end
   end
 
   class Slow
     include Qs::JobHandler
 
+    SLOW_TIME = 1
+
     def run!
-      sleep 5
+      sleep SLOW_TIME
       Qs.redis.with{ |c| c.set('qs-app:slow', 'finished') }
     end
   end
@@ -74,18 +81,22 @@ module AppHandlers
   class TimeoutEvent
     include Qs::EventHandler
 
-    timeout 0.2
+    TIMEOUT_TIME = 0.1
+
+    timeout TIMEOUT_TIME
 
     def run!
-      sleep 2
+      sleep 2*TIMEOUT_TIME
     end
   end
 
   class SlowEvent
     include Qs::EventHandler
 
+    SLOW_TIME = 1
+
     def run!
-      sleep 5
+      sleep SLOW_TIME
       Qs.redis.with{ |c| c.set('qs-app:slow:event', 'finished') }
     end
   end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -16,7 +16,7 @@ module Factory
   end
 
   def self.message(params = nil)
-    self.send([:job, :event].choice, params)
+    self.send([:job, :event].sample, params)
   end
 
   def self.job(args = nil)

--- a/test/unit/daemon_data_tests.rb
+++ b/test/unit/daemon_data_tests.rb
@@ -96,7 +96,7 @@ class Qs::DaemonData
     end
 
     should "look up a route using `route_for`" do
-      exp_route = @routes.choice
+      exp_route = @routes.sample
       assert_equal exp_route, subject.route_for(exp_route.id)
     end
 


### PR DESCRIPTION
This updates the gem dependencies to bring in the latest patches
(which also now work in modern ruby versions) and updates the test
suite to get things passing in modern ruby versions. This mostly
involved doing more "hand-holding" to ensure threads were given a
chance to run or to reach a certain state before any assertions
were made.

The test fixes include many tweaks including:

* switching to Array#sample (backfilled for 1.8.7)
* adding some extra thread joins to ensure they get a chance to run
* adding a test JOIN_SECONDS to standardize our thread joins
* adding constants for system test handler times and basing the
  test thread joins and sleeps on those times.  This allowed
  lowering some values so tests ran faster and added context to
  the test join and sleep times.
* proper signaling on the block dequeue daemon test to ensure they
  continue working once native threads become available
* switched the shutdown and requeue tests to not test requeue
  order.  This is unreliable and was only working b/c of
  constraints 1.8.7 put on thread scheduling.  This was exposed
  testing in modern ruby.

@jcredding ready for review.