### PR TITLE
add `halt` method to message handlers

### DIFF
--- a/lib/qs/message_handler.rb
+++ b/lib/qs/message_handler.rb
@@ -50,6 +50,7 @@ module Qs
 
       def logger; @qs_runner.logger; end
       def params; @qs_runner.params; end
+      def halt;   @qs_runner.halt;   end
 
     end
 

--- a/lib/qs/qs_runner.rb
+++ b/lib/qs/qs_runner.rb
@@ -15,10 +15,11 @@ module Qs
 
     def run
       MuchTimeout.optional_timeout(self.timeout, TimeoutInterrupt) do
-        self.handler.qs_run_callback 'before'
-        self.handler.qs_init
-        self.handler.qs_run
-        self.handler.qs_run_callback 'after'
+        catch(:halt) do
+          self.handler.qs_run_callback 'before'
+          catch(:halt){ self.handler.qs_init; self.handler.qs_run }
+          self.handler.qs_run_callback 'after'
+        end
       end
     rescue TimeoutInterrupt => exception
       error = Qs::TimeoutError.new "#{handler_class} timed out (#{timeout}s)"

--- a/lib/qs/runner.rb
+++ b/lib/qs/runner.rb
@@ -21,6 +21,10 @@ module Qs
       raise NotImplementedError
     end
 
+    def halt
+      throw :halt
+    end
+
   end
 
 end

--- a/lib/qs/test_runner.rb
+++ b/lib/qs/test_runner.rb
@@ -17,11 +17,21 @@ module Qs
       })
       a.each{ |key, value| self.handler.send("#{key}=", value) }
 
-      self.handler.qs_init
+      @halted = false
+      catch(:halt){ self.handler.qs_init }
     end
 
+    def halted?; @halted; end
+
     def run
-      self.handler.qs_run
+      catch(:halt){ self.handler.qs_run } if !self.halted?
+    end
+
+    # helpers
+
+    def halt
+      @halted = true
+      super
     end
 
     private

--- a/test/unit/message_handler_tests.rb
+++ b/test/unit/message_handler_tests.rb
@@ -236,10 +236,23 @@ module Qs::MessageHandler
       assert_equal @runner.params, subject.instance_eval{ params }
     end
 
+    should "call to the runner for its halt helper" do
+      capture_runner_meth_args_for(:halt)
+      subject.instance_eval{ halt }
+
+      assert_equal [], @meth_args
+    end
+
     private
 
     def stub_runner_with_something_for(meth)
       Assert.stub(@runner, meth){ @something }
+    end
+
+    def capture_runner_meth_args_for(meth)
+      Assert.stub(@runner, meth) do |*args|
+        @meth_args = args
+      end
     end
 
   end

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -25,7 +25,7 @@ class Qs::Runner
 
     should have_readers :handler_class, :handler
     should have_readers :logger, :message, :params
-    should have_imeths :run
+    should have_imeths :run, :halt
 
     should "know its handler class and handler" do
       assert_equal @handler_class, subject.handler_class
@@ -54,6 +54,14 @@ class Qs::Runner
 
     should "not implement its run method" do
       assert_raises(NotImplementedError){ subject.run }
+    end
+
+    should "halt execution with its halt method" do
+      something = nil
+      @runner_class.new(@handler_class).tap do |runner|
+        catch(:halt){ runner.halt; something = Factory.string }
+      end
+      assert_nil something
     end
 
   end

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -39,7 +39,7 @@ class Qs::TestRunner
     end
     subject{ @runner }
 
-    should have_imeths :run
+    should have_imeths :halted?, :run
 
     should "know its standard args" do
       assert_equal @args[:logger],  subject.logger
@@ -69,6 +69,17 @@ class Qs::TestRunner
 
     should "not call its handler's after callbacks" do
       assert_nil @handler.after_called
+    end
+
+    should "not be halted by default" do
+      assert_false subject.halted?
+    end
+
+    should "not call `run` on its handler if halted when run" do
+      catch(:halt){ subject.halt }
+      assert_true subject.halted?
+      subject.run
+      assert_nil @handler.run_called
     end
 
     should "stringify and encode the params passed to it" do


### PR DESCRIPTION
This method is similar to the `halt` method in Deas view handlers
and Sanford service handlers: it halts execution when called.  A
big difference with Qs' halt method, however, is that it takes no
args and there is no response handling to be concerned with.

This adds the method to the handler (which just proxies the runner
halt method) and implements the method on the runners.  This all
follows the pattern of Sanfords halt method and its tests.

@jcredding I totally just ripped off what Sanford did and how it tested its method.  Ready for review.