### PR TITLE
Add `NullClient`, throw uninitialized error when used

### DIFF
--- a/lib/qs.rb
+++ b/lib/qs.rb
@@ -41,19 +41,19 @@ module Qs
   end
 
   def self.enqueue(queue, job_name, params = nil)
-    @client.enqueue(queue, job_name, params)
+    self.client.enqueue(queue, job_name, params)
   end
 
   def self.publish(channel, name, params = nil)
-    @client.publish(channel, name, params)
+    self.client.publish(channel, name, params)
   end
 
   def self.publish_as(publisher, channel, name, params = nil)
-    @client.publish_as(publisher, channel, name, params)
+    self.client.publish_as(publisher, channel, name, params)
   end
 
   def self.push(queue_name, payload)
-    @client.push(queue_name, payload)
+    self.client.push(queue_name, payload)
   end
 
   def self.encode(payload)
@@ -77,7 +77,7 @@ module Qs
   end
 
   def self.client
-    @client
+    @client || NullClient.new
   end
 
   def self.redis
@@ -189,6 +189,21 @@ module Qs
 
   end
 
-  TimeoutError = Class.new(RuntimeError)
+  class NullClient
+    def initialize
+      @error = UninitializedError.new("Qs hasn't been initialized")
+    end
+
+    def enqueue(*args);             raise @error; end
+    def publish(*args);             raise @error; end
+    def publish_as(*args);          raise @error; end
+    def push(*args);                raise @error; end
+    def sync_subscriptions(*args);  raise @error; end
+    def clear_subscriptions(*args); raise @error; end
+    def event_subscribers(*args);   raise @error; end
+  end
+
+  UninitializedError = Class.new(RuntimeError)
+  TimeoutError       = Class.new(RuntimeError)
 
 end


### PR DESCRIPTION
This adds a `NullClient` that is the default client for qs if it
hasn't been initialized. This allows us to throw nicer unintialized
errors explaining that qs needs to be init instead of no method
errors.

`Qs` doesn't have a client until its init method is called but it
also demeters its client for convenience. This means that if the
demetered methods are used before `Qs` is init, it would throw
a no method error saying `nil` doesn't respond to the client
method. This changes `Qs` to return a `NullClient` if it hasn't
been initialized. The `NullClient` provides all the methods that
`Qs` demeters but simply raises an uninitialized error whenever
they are called. This lets users know that `Qs` hasn't been
initialized and needs to be before they try enqueueing, publishing,
etc.

Closes #71 

@kellyredding - Ready for review.