### PR TITLE
Update restart to use ruby 1.9+ `Kernel.exec`

### DIFF
--- a/bench/config.qs
+++ b/bench/config.qs
@@ -1,3 +1,4 @@
+$LOAD_PATH.push(File.expand_path('../..', __FILE__))
 require 'qs'
 
 ENV['LOG_NAME'] = 'log/bench_daemon.log'

--- a/bench/dispatcher.qs
+++ b/bench/dispatcher.qs
@@ -1,3 +1,4 @@
+$LOAD_PATH.push(File.expand_path('../..', __FILE__))
 require 'qs'
 
 ENV['LOG_NAME'] = 'log/bench_dispatcher_daemon.log'

--- a/bench/report.rb
+++ b/bench/report.rb
@@ -1,3 +1,5 @@
+$LOAD_PATH.push(File.expand_path('../..', __FILE__))
+
 require 'benchmark'
 require 'scmd'
 require 'bench/setup'

--- a/lib/qs/process.rb
+++ b/lib/qs/process.rb
@@ -100,7 +100,6 @@ module Qs
 
     def run_restart_cmd(daemon, restart_cmd)
       log "Restarting #{daemon.name} daemon"
-      ENV['QS_SKIP_DAEMONIZE'] = 'yes'
       restart_cmd.run
     end
 
@@ -124,9 +123,22 @@ module Qs
       @argv = [Gem.ruby, $0, ARGV.dup].flatten
     end
 
-    def run
-      Dir.chdir self.dir
-      Kernel.exec(*self.argv)
+    if RUBY_VERSION == '1.8.7'
+
+      def run
+        ENV['QS_SKIP_DAEMONIZE'] = 'yes'
+        Dir.chdir self.dir
+        Kernel.exec(*self.argv)
+      end
+
+    else
+
+      def run
+        env     = { 'QS_SKIP_DAEMONIZE' => 'yes' }
+        options = { :chdir => self.dir }
+        Kernel.exec(*([env] + self.argv + [options]))
+      end
+
     end
 
     private


### PR DESCRIPTION
This updates the `Process` restart to use ruby's 1.9+ `Kernel.exec`
interface. This is being done to keep consistent with sanford and
to prep us for supporting future ruby versions.

The `RestartCmd` now has a different run method depending on
which version of ruby is being used. For ruby 1.8.7, its run
method is mostly the same as it was before except it now handles
setting the skip daemonize env var. This also makes the
`RestartCmd` encapsulate all of the logic needed to restart the
daemon. For ruby 1.9+, the run method builds the env variable hash
and builds an exec options hash. The options hash simply tells the
exec to change the dir for now but could be expanded to set other
options if they are needed with future versions of ruby.

This also updates the bench script to work with ruby 1.9+. This
adds the root path to the load path since ruby doesn't do this
automatically anymore.

@kellyredding - Ready for review.