### PR TITLE
daemon: demeter config values that aren't directly set

### DIFF
--- a/lib/qs/daemon.rb
+++ b/lib/qs/daemon.rb
@@ -238,8 +238,16 @@ module Qs
         self.config.init_procs << block
       end
 
+      def init_procs
+        self.config.init_procs
+      end
+
       def error(&block)
         self.config.error_procs << block
+      end
+
+      def error_procs
+        self.config.error_procs
       end
 
       def logger(value = nil)

--- a/test/unit/daemon_tests.rb
+++ b/test/unit/daemon_tests.rb
@@ -22,7 +22,8 @@ module Qs::Daemon
     should have_imeths :config
     should have_imeths :name, :pid_file, :shutdown_timeout
     should have_imeths :worker_class, :worker_params, :num_workers, :workers
-    should have_imeths :init, :error, :logger, :queue, :queues
+    should have_imeths :init, :init_procs, :error, :error_procs
+    should have_imeths :logger, :queue, :queues
     should have_imeths :verbose_logging
 
     should "use much-plugin" do
@@ -57,13 +58,13 @@ module Qs::Daemon
       assert_equal exp, subject.config.num_workers
       assert_equal exp, subject.workers
 
-      exp = proc{ }
+      exp = proc{ Factory.string }
       assert_equal 0, config.init_procs.size
       subject.init(&exp)
       assert_equal 1, config.init_procs.size
       assert_equal exp, config.init_procs.first
 
-      exp = proc{ }
+      exp = proc{ Factory.string }
       assert_equal 0, config.error_procs.size
       subject.error(&exp)
       assert_equal 1, config.error_procs.size
@@ -80,6 +81,11 @@ module Qs::Daemon
       exp = Factory.boolean
       subject.verbose_logging exp
       assert_equal exp, config.verbose_logging
+    end
+
+    should "demeter its config values that aren't directly set" do
+      assert_equal subject.config.init_procs,  subject.init_procs
+      assert_equal subject.config.error_procs, subject.error_procs
     end
 
     should "know its queues" do


### PR DESCRIPTION
This allows for reading config values via the daemon directly as
the daemon tries to abstract its config. Since the other DSL
methods map one-to-one with their config values, they are their
own readers. This covers the config settings that aren't driven
by a direct DSL method.

@kellyredding - Ready for review.