### PR TITLE
Catch non `StandardError` exceptions in `PayloadHandler`

### DIFF
--- a/lib/qs/error_handler.rb
+++ b/lib/qs/error_handler.rb
@@ -1,8 +1,14 @@
+require 'dat-worker-pool/worker'
 require 'qs/queue'
 
 module Qs
 
   class ErrorHandler
+
+    # these are standard error classes that we rescue and run through any
+    # configured error procs; use the same standard error classes that
+    # dat-worker-pool rescues
+    STANDARD_ERROR_CLASSES = DatWorkerPool::Worker::STANDARD_ERROR_CLASSES
 
     attr_reader :exception, :context, :error_procs
 
@@ -21,7 +27,7 @@ module Qs
       @error_procs.each do |error_proc|
         begin
           error_proc.call(@exception, @context)
-        rescue StandardError => proc_exception
+        rescue *STANDARD_ERROR_CLASSES => proc_exception
           @exception = proc_exception
         end
       end

--- a/lib/qs/payload_handler.rb
+++ b/lib/qs/payload_handler.rb
@@ -50,7 +50,7 @@ module Qs
         handle_exception(error, daemon_data, queue_item)
       end
       raise exception
-    rescue StandardError => exception
+    rescue *Qs::ErrorHandler::STANDARD_ERROR_CLASSES => exception
       handle_exception(exception, daemon_data, queue_item)
     end
 

--- a/qs.gemspec
+++ b/qs.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("assert", ["~> 2.16.1"])
   gem.add_development_dependency("scmd",   ["~> 3.0.2"])
 
-  gem.add_dependency("dat-worker-pool", ["~> 0.6.1"])
+  gem.add_dependency("dat-worker-pool", ["~> 0.6.3"])
   gem.add_dependency("hella-redis",     ["~> 0.3.1"])
   gem.add_dependency("much-plugin",     ["~> 0.2.0"])
   gem.add_dependency("much-timeout",    ["~> 0.1.0"])

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,5 +1,6 @@
 require 'assert/factory'
 require 'qs/dispatch_job'
+require 'qs/error_handler'
 require 'qs/job'
 require 'qs/event'
 
@@ -13,6 +14,10 @@ module Factory
     begin; raise(klass, message); rescue klass => exception; end
     exception.set_backtrace(nil) if Factory.boolean
     exception
+  end
+
+  def self.qs_std_error(message = nil)
+    self.exception(Qs::ErrorHandler::STANDARD_ERROR_CLASSES.sample, message)
   end
 
   def self.message(params = nil)

--- a/test/unit/error_handler_tests.rb
+++ b/test/unit/error_handler_tests.rb
@@ -9,7 +9,7 @@ class Qs::ErrorHandler
   class UnitTests < Assert::Context
     desc "Qs::ErrorHandler"
     setup do
-      @exception       = Factory.exception
+      @exception       = Factory.qs_std_error
       @daemon_data     = Qs::DaemonData.new
       @queue_redis_key = Qs::Queue::RedisKey.new(Factory.string)
       @context_hash    = {
@@ -23,6 +23,11 @@ class Qs::ErrorHandler
       @handler_class = Qs::ErrorHandler
     end
     subject{ @handler_class }
+
+    should "know its standard error classes" do
+      exp = DatWorkerPool::Worker::STANDARD_ERROR_CLASSES
+      assert_equal exp, subject::STANDARD_ERROR_CLASSES
+    end
 
   end
 
@@ -79,7 +84,7 @@ class Qs::ErrorHandler
     desc "and run with error procs that throw exceptions"
     setup do
       @proc_exceptions = @error_proc_spies.reverse.map do |spy|
-        exception = Factory.exception(RuntimeError, @error_proc_spies.index(spy).to_s)
+        exception = Factory.qs_std_error(@error_proc_spies.index(spy).to_s)
         spy.raise_exception = exception
         exception
       end

--- a/test/unit/payload_handler_tests.rb
+++ b/test/unit/payload_handler_tests.rb
@@ -77,7 +77,7 @@ class Qs::PayloadHandler
 
   class RunWithExceptionSetupTests < InitTests
     setup do
-      @route_exception = Factory.exception
+      @route_exception = Factory.qs_std_error
       Assert.stub(@route_spy, :run){ raise @route_exception }
       Assert.stub(Qs::ErrorHandler, :new) do |*args|
         @error_handler_spy = ErrorHandlerSpy.new(*args)
@@ -186,7 +186,7 @@ class Qs::PayloadHandler
   class LoggingJobErrorTests < LoggingJobSetupTests
     desc "that errors while being processed"
     setup do
-      @route_exception = Factory.exception
+      @route_exception = Factory.qs_std_error
       Assert.stub(@route_spy, :run){ raise @route_exception }
 
       @payload_handler.run
@@ -260,7 +260,7 @@ class Qs::PayloadHandler
   class LoggingEventErrorTests < LoggingEventSetupTests
     desc "that errors while being processed"
     setup do
-      @route_exception = Factory.exception
+      @route_exception = Factory.qs_std_error
       Assert.stub(@route_spy, :run){ raise @route_exception }
 
       @payload_handler.run
@@ -294,7 +294,7 @@ class Qs::PayloadHandler
       @message = Factory.message
       setup_for_message(@message)
 
-      Assert.stub(Qs::Payload, :deserialize){ raise Factory.exception }
+      Assert.stub(Qs::Payload, :deserialize){ raise Factory.qs_std_error }
 
       @payload_handler = @handler_class.new(@daemon_data, @queue_item)
       @payload_handler.run
@@ -430,7 +430,7 @@ class Qs::PayloadHandler
     def initialize(exception, context_hash)
       @passed_exception = exception
       @context_hash     = context_hash
-      @exception        = Factory.exception
+      @exception        = Factory.qs_std_error
       @run_called       = false
     end
 


### PR DESCRIPTION
This updates the `PayloadHandler` and `ErrorHandler` to catch
non `StandardError` exceptions. This updates qs to rescue the same
exceptions that dat-worker-pool workers will rescue. These are
exceptions that we want to run through the configured error procs
even though they don't inherit from `StandardError` because they
won't shutdown the worker thread but they do cause a job/event to
fail being processed. This includes ruby's `Timeout::Error`,
`LoadError` and `NotImplementedError`.

This updates the `PayloadHandler` to not only rescue
`StandardError` but instead use dat-worker-pool's standard error
classes. Just like all standard errors have been up to this point,
any of these errors will be passed to the error handler which will
run through the configured error procs.

The `ErrorHandler` also rescues dat-worker-pool's standard error
classes while it is running configured error procs. This is
intended to be consistent with the payload handler; we want to
rescue the same kind of errors that happen while trying to run an
error proc. This ensures we are consistent in our error handling
while processing a job or event.

@kellyredding - Ready for review.