### PR TITLE
update the error handler error context to fetch its data

### DIFF
--- a/lib/qs/error_handler.rb
+++ b/lib/qs/error_handler.rb
@@ -41,11 +41,11 @@ module Qs
     attr_reader :message, :handler_class
 
     def initialize(args)
-      @daemon_data     = args[:daemon_data]
-      @queue_name      = Queue::RedisKey.parse_name(args[:queue_redis_key].to_s)
-      @encoded_payload = args[:encoded_payload]
-      @message         = args[:message]
-      @handler_class   = args[:handler_class]
+      @daemon_data     = args.fetch(:daemon_data)
+      @queue_name      = get_queue_name(args.fetch(:queue_redis_key))
+      @encoded_payload = args.fetch(:encoded_payload)
+      @message         = args.fetch(:message)
+      @handler_class   = args.fetch(:handler_class)
     end
 
     def ==(other)
@@ -59,6 +59,13 @@ module Qs
         super
       end
     end
+
+    private
+
+    def get_queue_name(redis_key)
+      Queue::RedisKey.parse_name(redis_key.to_s)
+    end
+
   end
 
 end

--- a/test/unit/error_handler_tests.rb
+++ b/test/unit/error_handler_tests.rb
@@ -128,7 +128,13 @@ class Qs::ErrorHandler
       exp = Qs::ErrorContext.new(@context_hash)
       assert_equal exp, subject
 
-      exp = Qs::ErrorContext.new({})
+      exp = Qs::ErrorContext.new({
+        :daemon_data     => Qs::DaemonData.new,
+        :queue_redis_key => Qs::Queue::RedisKey.new(Factory.string),
+        :encoded_payload => Factory.string,
+        :message         => Factory.string,
+        :handler_class   => Factory.string
+      })
       assert_not_equal exp, subject
     end
 


### PR DESCRIPTION
This is to enforce that if the context expects a value qs
supplies it. This also closes a gap in our tests and tests that
qs is creating the context as necessary.

This is similar to a change Deas did to its error handler context
in redding/deas#223.

@jcredding ready for review