### PR TITLE
update to the latest HellaRedis

### DIFF
--- a/lib/qs.rb
+++ b/lib/qs.rb
@@ -152,7 +152,7 @@ module Qs
     end
 
     # the keys here should be compatible with HellaRedis connection configs
-    # https://github.com/redding/hella-redis#connection
+    # https://github.com/redding/hella-redis#usage
     def redis_connect_hash
       { :ip       => self.redis_ip,
         :port     => self.redis_port,

--- a/qs.gemspec
+++ b/qs.gemspec
@@ -18,12 +18,12 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.16.1"])
-  gem.add_development_dependency("scmd",   ["~> 3.0.2"])
+  gem.add_development_dependency("assert", ["~> 2.16.3"])
+  gem.add_development_dependency("scmd",   ["~> 3.0.3"])
 
   gem.add_dependency("dat-worker-pool", ["~> 0.6.3"])
-  gem.add_dependency("hella-redis",     ["~> 0.3.1"])
+  gem.add_dependency("hella-redis",     ["~> 0.4.0"])
   gem.add_dependency("much-plugin",     ["~> 0.2.0"])
-  gem.add_dependency("much-timeout",    ["~> 0.1.0"])
+  gem.add_dependency("much-timeout",    ["~> 0.1.1"])
 
 end

--- a/test/support/app_queue.rb
+++ b/test/support/app_queue.rb
@@ -27,7 +27,7 @@ module AppHandlers
     include Qs::JobHandler
 
     def run!
-      Qs.redis.with{ |c| c.set("qs-app:#{params['key']}", params['value']) }
+      Qs.redis.connection{ |c| c.set("qs-app:#{params['key']}", params['value']) }
     end
   end
 
@@ -58,7 +58,7 @@ module AppHandlers
 
     def run!
       sleep SLOW_TIME
-      Qs.redis.with{ |c| c.set('qs-app:slow', 'finished') }
+      Qs.redis.connection{ |c| c.set('qs-app:slow', 'finished') }
     end
   end
 
@@ -66,7 +66,7 @@ module AppHandlers
     include Qs::EventHandler
 
     def run!
-      Qs.redis.with{ |c| c.set("qs-app:#{params['key']}", params['value']) }
+      Qs.redis.connection{ |c| c.set("qs-app:#{params['key']}", params['value']) }
     end
   end
 
@@ -97,7 +97,7 @@ module AppHandlers
 
     def run!
       sleep SLOW_TIME
-      Qs.redis.with{ |c| c.set('qs-app:slow:event', 'finished') }
+      Qs.redis.connection{ |c| c.set('qs-app:slow:event', 'finished') }
     end
   end
 


### PR DESCRIPTION
This version has breaking changes to the API and to how testing
is handled. This updates to use the new API.

This version of HellaRedis supports test mode env setup. In test
mode, all connection pools will be spies. However, Qs already
has its own test mode handling.  This doesn't use any of
HellaRedis's test mode env stuff, but it does switch to using
the new API to build real vs mock connection pools.  This also
switches to use the new API for the connection pools.

See redding/hella-redis#11 and redding/hella-redis#14 for
reference on the API changes.

@jcredding ready for review.